### PR TITLE
Remove the possible previous zip files from /tmp

### DIFF
--- a/src/install-boxlang.sh
+++ b/src/install-boxlang.sh
@@ -90,10 +90,12 @@ main() {
 	mkdir -p /usr/local/lib
 
 	# Download
+	rm -f /tmp/boxlang.zip
 	env curl -Lk -o /tmp/boxlang.zip "${DOWNLOAD_URL}" || {
 		printf "Error: Download of BoxLang® binary failed\n"
 		exit 1
 	}
+	rm -f /tmp/boxlang-miniserver.zip
 	env curl -Lk -o /tmp/boxlang-miniserver.zip "${DOWNLOAD_URL_MINISERVER}" || {
 		printf "Error: Download of BoxLang® MiniServer binary failed\n"
 		exit 1


### PR DESCRIPTION
There are a condition when installing boxlang that cause an error in the curl download. 

Steps to reproduce: 

1) Run the `install-boxlang.sh` command from a regular user, it fails beacuse it can write to system dirs: 

```
Unzipping BoxLang...

Archive:  /tmp/boxlang.zip
error:  cannot delete old /usr/local/bin/boxlang
        Permission denied
error:  cannot create /usr/local/bin/boxlang.bat
        Permission denied
error:  cannot delete old /usr/local/lib/boxlang-1.0.0-all.jar
        Permission denied
```

In this step, the script doesn't do the cleanup of downloaded files in /tmp

2) The user do the normal `sudo`  with the same command.  Now the curl step complains that it can't write the files in /tmp/  as it not from the same user (it's a security feature of modern Linux).

```
curl: (23) Failure writing output to destination
Error: Download of BoxLang® binary failed
``` 

This PR do a preventive remove of the two downloaded files



