### PR TITLE
Add powershell scripts to install modules on windows

### DIFF
--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -1,0 +1,71 @@
+param(
+    [Parameter(Mandatory)]
+    [string]
+    $Module,
+
+    [Parameter(Mandatory=$false)]
+    [string]
+    $Version
+)
+
+$Module = $Module.toLower()
+
+if ([string]::IsNullOrEmpty($Version)){
+    Write-Host -ForegroundColor Yellow "No version provided, using latest from https://forgebox.io"
+    $ForgeBoxResponse = Invoke-RestMethod -Uri "https://forgebox.io/api/v1/entry/$Module/latest" -Method Get
+    if ($ForgeBoxResponse){
+        $ModuleDownloadUrl = "$($ForgeBoxResponse.data.downloadURL)"
+    } else {
+        Write-Host -ForegroundColor Red "No data received from https://forgebox.io/api/v1/entry/$Module/latest"
+    }
+} else {
+    $ModuleDownloadUrl = "https://downloads.ortussolutions.com/ortussolutions/boxlang-modules/$Module/$Version/$Module-$Version.zip"
+}
+
+if (!$Env:BOXLANG_HOME){
+    $Env:BOXLANG_HOME = Join-Path -Path "$Env:USERPROFILE" -ChildPath ".boxlang"
+}
+
+$ModuleHome = Join-Path -Path "$Env:BOXLANG_HOME" -ChildPath "modules"
+$ModuleDestination = Join-Path -Path "$ModuleHome" -ChildPath "$Module"
+
+Write-Host -ForegroundColor Gree ''
+Write-Host -ForegroundColor Gree '*************************************************************************'
+Write-Host -ForegroundColor Gree 'Welcome to the BoxLang® Module Quick Installer'
+Write-Host -ForegroundColor Gree '*************************************************************************'
+Write-Host -ForegroundColor Gree 'This will download and install the requested module into you'
+Write-Host -ForegroundColor Gree "BoxLang® HOME directory at [$ModuleDestination]"
+Write-Host -ForegroundColor Gree '*************************************************************************'
+Write-Host -ForegroundColor Gree 'You can also download the BoxLang® modules from https://forgebox.io'
+Write-Host -ForegroundColor Gree '*************************************************************************'
+
+Write-Host -ForegroundColor Yellow "Please wait..."
+
+New-Item -Path "$ModuleHome" -ItemType "directory" -Force | Out-Null
+
+$ZipFileName = "$Module.zip"
+$ZipFileModulePath = Join-Path -Path $ModuleHome -ChildPath $ZipFileName
+
+Write-Host -ForegroundColor Blue "Downloading Module [$Module] from [$ModuleDownloadUrl]"
+Invoke-WebRequest -Uri $ModuleDownloadUrl -OutFile $ZipFileModulePath
+
+if (Test-Path -Path $ModuleDestination){
+    Remove-Item -Path $ModuleDestination -Recurse -Force
+}
+
+New-Item -Path "$ModuleDestination" -ItemType "directory" -Force | Out-Null
+Expand-Archive -Path $ZipFileModulePath -DestinationPath $ModuleDestination
+Remove-Item -Path $ZipFileModulePath -Force
+Write-Host -ForegroundColor Green ''
+Write-Host -ForegroundColor Green "BoxLang® Module [$Module@$Version] installed to [$ModuleDestination]"
+Write-Host -ForegroundColor Green ''
+Write-Host -ForegroundColor Green '*************************************************************************'
+Write-Host -ForegroundColor Green 'BoxLang® - Dynamic : Modular : Productive : https://boxlang.io'
+Write-Host -ForegroundColor Green '*************************************************************************'
+Write-Host -ForegroundColor Green "BoxLang® is FREE and Open-Source Software under the Apache 2.0 License"
+Write-Host -ForegroundColor Green "You can also buy support and enhanced versions at https://boxlang.io/plans"
+Write-Host -ForegroundColor Green 'p.s. Follow us at https://twitter.com/ortussolutions.'
+Write-Host -ForegroundColor Green 'p.p.s. Clone us and star us at https://github.com/ortus-boxlang/boxlang'
+Write-Host -ForegroundColor Green 'Please support us via Patreon at https://www.patreon.com/ortussolutions'
+Write-Host -ForegroundColor Green '*************************************************************************'
+Write-Host -ForegroundColor Green "Copyright and Registered Trademarks of Ortus Solutions, Corp"

--- a/src/install-bx-modules.ps1
+++ b/src/install-bx-modules.ps1
@@ -1,0 +1,42 @@
+# Check if at least one argument is passed
+if ($args.Count -eq 0){
+    Write-Host -ForegroundColor Red "Usage: " $MyInvocation.MyCommand.Name "module1 module2 module3 ..."
+    exit 1
+}
+
+# Install modules in parallel
+Write-Host -ForegroundColor Green "Install the following modules: $args"
+$jobs = @()
+foreach ($module in $args){
+    $job = Start-Job -ScriptBlock {
+        param ($module)
+
+        & "install-bx-module" $module
+        Write-Host ""
+        Write-Host "*************************************************************************"
+        Write-Host ""
+    } -ArgumentList $module
+
+
+    $jobs += $job
+}
+
+# Wait for all jobs to finish
+$jobs | ForEach-Object {
+    Wait-Job -Job $_ | Out-Null
+    Receive-Job -Job $_ | Out-Null
+    Remove-Job -Job $_ | Out-Null
+}
+
+Write-Host -ForegroundColor Green "BoxLang® Modules [$args] installed to [$Env:BOXLANG_HOME\modules]"
+Write-Host -ForegroundColor Green ''
+Write-Host -ForegroundColor Green '*************************************************************************'
+Write-Host -ForegroundColor Green 'BoxLang® - Dynamic : Modular : Productive : https://boxlang.io'
+Write-Host -ForegroundColor Green '*************************************************************************'
+Write-Host -ForegroundColor Green "BoxLang® is FREE and Open-Source Software under the Apache 2.0 License"
+Write-Host -ForegroundColor Green "You can also buy support and enhanced versions at https://boxlang.io/plans"
+Write-Host -ForegroundColor Green 'p.s. Follow us at https://twitter.com/ortussolutions.'
+Write-Host -ForegroundColor Green 'p.p.s. Clone us and star us at https://github.com/ortus-boxlang/boxlang'
+Write-Host -ForegroundColor Green 'Please support us via Patreon at https://www.patreon.com/ortussolutions'
+Write-Host -ForegroundColor Green '*************************************************************************'
+Write-Host -ForegroundColor Green "Copyright and Registered Trademarks of Ortus Solutions, Corp"


### PR DESCRIPTION
The following scripts were added to install Boxlang Modules on Windows, scripts work similar to Bash scripts
* install-bx-module.ps1
* install-bx-modules.ps1