### PR TITLE
Move functions up and fix version check

### DIFF
--- a/src/install-boxlang.ps1
+++ b/src/install-boxlang.ps1
@@ -235,7 +235,7 @@ function Get-LatestBoxLangVersion {
         }
 
         # Extract version from properties file (format: version=1.2.3+buildId)
-        $versionLines = $versionInfo.Content -split "`n"
+        $versionLines = $versionInfo -split "`n"
         foreach ($line in $versionLines) {
             if ($line -match "^version=(.+)$") {
                 $latestVersion = Get-SemanticVersion -VersionString $matches[1]


### PR DESCRIPTION
The functions need to be before they're called and the version compare wasn't correctly going line-by-line.  
I've now tested install, uninstall and check-update