### PR TITLE
install-bx-module PS script corrections

### DIFF
--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -377,7 +377,7 @@ if ($args[0] -eq "--list") {
     }
 
     # Ensure no other arguments after --list [--local]
-    if ($remainingArgs.Count -gt 0) {
+    if ($remainingArgs.Count -gt 1) {
         Write-Host "❌ Error: --list command does not accept additional arguments" -ForegroundColor Red
         Write-Host "💡 Usage: install-bx-module.ps1 --list [--local]" -ForegroundColor Yellow
         exit 1


### PR DESCRIPTION
There were a few errors in this script where
1) $input is a reserved variable name in PowerShell
2) The --list argument had a comparison number error as it will always have 1 argument (the --list itself)