### PR TITLE
Track installed modules in a box.json dependencies manifest

### DIFF
--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -204,6 +204,8 @@ function Show-Help {
     Write-Host "  install-bx-module.ps1 <module-name>[@<version>] [<module-name>[@<version>] ...] [--local]"
     Write-Host "  install-bx-module.ps1 --remove <module-name> [<module-name> ...] [--force] [--local]"
     Write-Host "  install-bx-module.ps1 --list [--local]"
+    Write-Host "  install-bx-module.ps1 --outdated [--local]"
+    Write-Host "  install-bx-module.ps1 --update [--force] [--local]"
     Write-Host "  install-bx-module.ps1 --help"
     Write-Host ""
     Write-Host "Arguments:" -ForegroundColor DarkYellow
@@ -213,8 +215,10 @@ function Show-Help {
     Write-Host "Options:" -ForegroundColor DarkYellow
     Write-Host "  --local           Install to/remove from local boxlang_modules folder instead of BoxLang HOME. The BoxLang HOME is the default."
     Write-Host "  --remove          Remove specified module(s)"
-    Write-Host "  --force           Skip confirmation when removing modules(s)(use with --remove)"
+    Write-Host "  --force           Skip confirmation when removing or updating module(s) (use with --remove or --update)"
     Write-Host "  --list            Show installed module(s)"
+    Write-Host "  --outdated        Check installed modules against FORGEBOX and report which are outdated"
+    Write-Host "  --update          Update all outdated module(s) to their latest FORGEBOX version"
     Write-Host "  --help, -h        Show this help message"
     Write-Host ""
     Write-Host "Examples:" -ForegroundColor DarkYellow
@@ -228,6 +232,10 @@ function Show-Help {
     Write-Host "  install-bx-module.ps1 --remove `"bx-orm, bx-ai`" --local"
     Write-Host "  install-bx-module.ps1 --list"
     Write-Host "  install-bx-module.ps1 --list --local"
+    Write-Host "  install-bx-module.ps1 --outdated"
+    Write-Host "  install-bx-module.ps1 --outdated --local"
+    Write-Host "  install-bx-module.ps1 --update"
+    Write-Host "  install-bx-module.ps1 --update --force --local"
     Write-Host ""
     Write-Host "Notes:" -ForegroundColor DarkYellow
     Write-Host "  - If no version is specified, the latest version from FORGEBOX will be installed"
@@ -269,19 +277,8 @@ function Remove-BoxJsonDependency {
     $boxJson | ConvertTo-Json -Depth 10 | Set-Content -Path $BoxJsonPath
 }
 
-function List-Modules {
-    param(
-        [string]$ModulesPath,
-        [string]$LocationDesc
-    )
-
-    Write-Host "📋 Installed BoxLang Modules ($LocationDesc):" -ForegroundColor Yellow
-
-    # Check if modules directory exists
-    if (-not (Test-Path $ModulesPath)) {
-        Write-Host "📂 No modules directory found at $ModulesPath" -ForegroundColor Yellow
-        return
-    }
+function Get-ModulesManifestPath {
+    param([string]$ModulesPath)
 
     $boxJsonPath = Join-Path $ModulesPath "box.json"
 
@@ -308,6 +305,25 @@ function List-Modules {
         }
     }
 
+    return $boxJsonPath
+}
+
+function List-Modules {
+    param(
+        [string]$ModulesPath,
+        [string]$LocationDesc
+    )
+
+    Write-Host "📋 Installed BoxLang Modules ($LocationDesc):" -ForegroundColor Yellow
+
+    # Check if modules directory exists
+    if (-not (Test-Path $ModulesPath)) {
+        Write-Host "📂 No modules directory found at $ModulesPath" -ForegroundColor Yellow
+        return
+    }
+
+    $boxJsonPath = Get-ModulesManifestPath $ModulesPath
+
     # Read installed modules from the manifest
     $dependencies = $null
     if (Test-Path $boxJsonPath) {
@@ -327,6 +343,209 @@ function List-Modules {
             Write-Host "✓ $($prop.Name) ($($prop.Value))" -ForegroundColor Green
         }
     }
+}
+
+###########################################################################
+# Version Comparison Functions
+###########################################################################
+
+# Extract semantic version (Major.Minor.Patch) from a version string
+function Get-SemanticVersion {
+    param([string]$VersionString)
+
+    if ($VersionString -match '(\d+\.\d+\.\d+)') {
+        return $matches[1]
+    }
+    return $null
+}
+
+# Compare two semantic versions (Major.Minor.Patch)
+# Returns: 0 if equal, 1 if first > second, -1 if first < second
+function Compare-Versions {
+    param(
+        [string]$Version1,
+        [string]$Version2
+    )
+
+    $v1Parts = $Version1.Split('.')
+    $v2Parts = $Version2.Split('.')
+
+    for ($i = 0; $i -lt 3; $i++) {
+        $v1Part = if ($i -lt $v1Parts.Length) { [int]$v1Parts[$i] } else { 0 }
+        $v2Part = if ($i -lt $v2Parts.Length) { [int]$v2Parts[$i] } else { 0 }
+
+        if ($v1Part -gt $v2Part) { return 1 }
+        elseif ($v1Part -lt $v2Part) { return -1 }
+    }
+
+    return 0
+}
+
+###########################################################################
+# Outdated / Update Functions
+###########################################################################
+
+# Lean ForgeBox "latest version" lookup (no progress messages, no download URL resolution).
+function Get-ForgeboxLatestVersion {
+    param([string]$ModuleName)
+
+    try {
+        $entryJson = Invoke-RestMethod -Uri "$FORGEBOX_API_URL/entry/$ModuleName/latest" -ErrorAction Stop
+        if ($entryJson -and $entryJson.data -and $entryJson.data.version) {
+            return $entryJson.data.version
+        }
+    } catch {
+        return $null
+    }
+    return $null
+}
+
+# Returns an array of [PSCustomObject]@{ Name; Current; Latest; Status } for every
+# dependency in the manifest. Status is one of: uptodate, ahead, outdated, unreachable.
+# Dependencies whose current version isn't a parseable semver are skipped entirely.
+function Get-OutdatedReport {
+    param([string]$ModulesPath)
+
+    $boxJsonPath = Get-ModulesManifestPath $ModulesPath
+    $dependencies = $null
+    try {
+        $manifest = Get-Content $boxJsonPath -Raw | ConvertFrom-Json
+        if ($manifest.dependencies) { $dependencies = $manifest.dependencies }
+    } catch { }
+
+    $report = @()
+    if (-not $dependencies) { return $report }
+
+    foreach ($prop in $dependencies.PSObject.Properties) {
+        $moduleName = $prop.Name
+        $currentVersion = $prop.Value
+
+        $currentSemver = Get-SemanticVersion $currentVersion
+        if (-not $currentSemver) { continue }
+
+        $latestVersion = Get-ForgeboxLatestVersion $moduleName
+        $status = $null
+        if (-not $latestVersion) {
+            $status = "unreachable"
+            $latestVersion = "?"
+        } else {
+            $latestSemver = Get-SemanticVersion $latestVersion
+            if (-not $latestSemver) {
+                $status = "unreachable"
+            } else {
+                $cmp = Compare-Versions -Version1 $currentSemver -Version2 $latestSemver
+                switch ($cmp) {
+                    0  { $status = "uptodate" }
+                    1  { $status = "ahead" }
+                    -1 { $status = "outdated" }
+                }
+            }
+        }
+
+        $report += [PSCustomObject]@{
+            Name = $moduleName
+            Current = $currentVersion
+            Latest = $latestVersion
+            Status = $status
+        }
+    }
+
+    return $report
+}
+
+function Show-Outdated {
+    param(
+        [string]$ModulesPath,
+        [string]$LocationDesc
+    )
+
+    Write-Host "🔎 Checking for outdated BoxLang Modules ($LocationDesc):" -ForegroundColor Yellow
+    Write-Host ""
+
+    if (-not (Test-Path $ModulesPath)) {
+        Write-Host "📂 No modules directory found at $ModulesPath" -ForegroundColor Yellow
+        return
+    }
+
+    $report = Get-OutdatedReport $ModulesPath
+
+    if ($report.Count -eq 0) {
+        Write-Host "📭 No modules to report on" -ForegroundColor Yellow
+        return
+    }
+
+    "{0,-25} {1,-15} {2,-15} {3}" -f "DEPENDENCY", "CURRENT", "FORGEBOX", "STATUS" | Write-Host
+    "{0,-25} {1,-15} {2,-15} {3}" -f "-------------------------", "---------------", "---------------", "--------------------" | Write-Host
+
+    $outdated = @()
+    foreach ($entry in $report) {
+        $statusLabel = switch ($entry.Status) {
+            "uptodate" { "✅ up to date" }
+            "ahead" { "🔄 ahead (dev/snapshot)" }
+            "outdated" { $outdated += $entry; "🆙 outdated" }
+            default { "⚠️  unable to check" }
+        }
+        "{0,-25} {1,-15} {2,-15} {3}" -f $entry.Name, $entry.Current, $entry.Latest, $statusLabel | Write-Host
+    }
+
+    Write-Host ""
+    if ($outdated.Count -eq 0) {
+        Write-Host "✅ All modules are up to date" -ForegroundColor Green
+        return
+    }
+
+    Write-Host "⚠️  $($outdated.Count) module(s) outdated" -ForegroundColor Yellow
+    $confirmation = Read-Host "⬆️  Would you like to update $($outdated.Count) outdated module(s) now? [y/N]"
+    if ($confirmation -match "^[yY]([eE][sS])?$") {
+        foreach ($entry in $outdated) {
+            Install-Module "$($entry.Name)@$($entry.Latest)"
+        }
+    } else {
+        Write-Host "Skipping updates." -ForegroundColor Yellow
+    }
+}
+
+function Update-Modules {
+    param(
+        [string]$ModulesPath,
+        [string]$LocationDesc,
+        [bool]$ForceUpdate = $false
+    )
+
+    Write-Host "🔎 Checking for outdated BoxLang Modules ($LocationDesc):" -ForegroundColor Yellow
+    Write-Host ""
+
+    if (-not (Test-Path $ModulesPath)) {
+        Write-Host "📂 No modules directory found at $ModulesPath" -ForegroundColor Yellow
+        return
+    }
+
+    $report = Get-OutdatedReport $ModulesPath
+    $outdated = $report | Where-Object { $_.Status -eq "outdated" }
+
+    foreach ($entry in $outdated) {
+        Write-Host "🆙 $($entry.Name): $($entry.Current) → $($entry.Latest)"
+    }
+
+    if (-not $outdated -or $outdated.Count -eq 0) {
+        Write-Host "✅ All modules are up to date, nothing to update" -ForegroundColor Green
+        return
+    }
+
+    Write-Host ""
+    if (-not $ForceUpdate) {
+        $confirmation = Read-Host "⬆️  Update $($outdated.Count) outdated module(s)? [y/N]"
+        if ($confirmation -notmatch "^[yY]([eE][sS])?$") {
+            Write-Host "❌ Update cancelled" -ForegroundColor Yellow
+            return
+        }
+    }
+
+    foreach ($entry in $outdated) {
+        Install-Module "$($entry.Name)@$($entry.Latest)"
+    }
+
+    Write-Host "✅ Updated $($outdated.Count) module(s)!" -ForegroundColor Green
 }
 
 function Get-LatestVersionFromForgebox {
@@ -684,6 +903,82 @@ if ($args[0] -eq "--list") {
     }
 
     List-Modules $modulesPath $locationDesc
+    exit 0
+}
+
+# Handle --outdated command (can be used with --local)
+if ($args[0] -eq "--outdated") {
+    $remainingArgs = @()
+    if ($args.Count -gt 1) {
+        $remainingArgs = $args[1..($args.Count-1)]
+    }
+
+    $OUTDATED_LOCAL = $false
+    if ($remainingArgs -contains "--local") {
+        $OUTDATED_LOCAL = $true
+        $remainingArgs = $remainingArgs | Where-Object { $_ -ne "--local" }
+    }
+
+    if ($remainingArgs.Count -gt 0) {
+        Write-Host "❌ Error: --outdated command does not accept additional arguments" -ForegroundColor Red
+        Write-Host "💡 Usage: install-bx-module.ps1 --outdated [--local]" -ForegroundColor Yellow
+        exit 1
+    }
+
+    $LOCAL_INSTALL = $OUTDATED_LOCAL
+    if ($OUTDATED_LOCAL) {
+        $MODULES_HOME = Join-Path (Get-Location) "boxlang_modules"
+        $locationDesc = "Local - $(Get-Location)\boxlang_modules"
+    } else {
+        if (-not $env:BOXLANG_HOME) {
+            $env:BOXLANG_HOME = Join-Path $env:USERPROFILE ".boxlang"
+        }
+        $MODULES_HOME = Join-Path $env:BOXLANG_HOME "modules"
+        $locationDesc = "Global - $($env:BOXLANG_HOME)\modules"
+    }
+
+    Show-Outdated $MODULES_HOME $locationDesc
+    exit 0
+}
+
+# Handle --update command (can be used with --force and --local, in any order)
+if ($args[0] -eq "--update") {
+    $remainingArgs = @()
+    if ($args.Count -gt 1) {
+        $remainingArgs = $args[1..($args.Count-1)]
+    }
+
+    $FORCE_UPDATE = $false
+    if ($remainingArgs -contains "--force") {
+        $FORCE_UPDATE = $true
+        $remainingArgs = $remainingArgs | Where-Object { $_ -ne "--force" }
+    }
+
+    $UPDATE_LOCAL = $false
+    if ($remainingArgs -contains "--local") {
+        $UPDATE_LOCAL = $true
+        $remainingArgs = $remainingArgs | Where-Object { $_ -ne "--local" }
+    }
+
+    if ($remainingArgs.Count -gt 0) {
+        Write-Host "❌ Error: --update command does not accept additional arguments" -ForegroundColor Red
+        Write-Host "💡 Usage: install-bx-module.ps1 --update [--force] [--local]" -ForegroundColor Yellow
+        exit 1
+    }
+
+    $LOCAL_INSTALL = $UPDATE_LOCAL
+    if ($UPDATE_LOCAL) {
+        $MODULES_HOME = Join-Path (Get-Location) "boxlang_modules"
+        $locationDesc = "Local - $(Get-Location)\boxlang_modules"
+    } else {
+        if (-not $env:BOXLANG_HOME) {
+            $env:BOXLANG_HOME = Join-Path $env:USERPROFILE ".boxlang"
+        }
+        $MODULES_HOME = Join-Path $env:BOXLANG_HOME "modules"
+        $locationDesc = "Global - $($env:BOXLANG_HOME)\modules"
+    }
+
+    Update-Modules $MODULES_HOME $locationDesc $FORCE_UPDATE
     exit 0
 }
 

--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -238,6 +238,37 @@ function Show-Help {
     Write-Host "  - Requires PowerShell to be installed"
 }
 
+function Set-BoxJsonDependency {
+    param([string]$BoxJsonPath, [string]$ModuleName, [string]$ModuleVersion)
+
+    $boxJson = $null
+    if (Test-Path $BoxJsonPath) {
+        try { $boxJson = Get-Content $BoxJsonPath -Raw | ConvertFrom-Json } catch { $boxJson = $null }
+    }
+    if (-not $boxJson) { $boxJson = [PSCustomObject]@{} }
+
+    if (-not ($boxJson.PSObject.Properties.Name -contains 'dependencies') -or -not $boxJson.dependencies) {
+        $boxJson | Add-Member -MemberType NoteProperty -Name dependencies -Value ([PSCustomObject]@{}) -Force
+    }
+
+    $boxJson.dependencies | Add-Member -MemberType NoteProperty -Name $ModuleName -Value $ModuleVersion -Force
+    $boxJson | ConvertTo-Json -Depth 10 | Set-Content -Path $BoxJsonPath
+}
+
+function Remove-BoxJsonDependency {
+    param([string]$BoxJsonPath, [string]$ModuleName)
+
+    if (-not (Test-Path $BoxJsonPath)) { return }
+    try { $boxJson = Get-Content $BoxJsonPath -Raw | ConvertFrom-Json } catch { return }
+    if (-not $boxJson) { return }
+
+    if (($boxJson.PSObject.Properties.Name -contains 'dependencies') -and $boxJson.dependencies -and
+        ($boxJson.dependencies.PSObject.Properties.Name -contains $ModuleName)) {
+        $boxJson.dependencies.PSObject.Properties.Remove($ModuleName)
+    }
+    $boxJson | ConvertTo-Json -Depth 10 | Set-Content -Path $BoxJsonPath
+}
+
 function List-Modules {
     param(
         [string]$ModulesPath,
@@ -252,32 +283,48 @@ function List-Modules {
         return
     }
 
-    # List all directories in the modules folder
-    $moduleDirectories = Get-ChildItem -Path $ModulesPath -Directory -ErrorAction SilentlyContinue
+    $boxJsonPath = Join-Path $ModulesPath "box.json"
 
-    if (-not $moduleDirectories) {
-        Write-Host "📭 No modules installed" -ForegroundColor Yellow
-    } else {
-        # List modules with version information from box.json
+    # Backfill: generate the manifest from installed modules if it doesn't exist yet
+    # (e.g. modules installed before this feature existed, or by an older script version)
+    if (-not (Test-Path $boxJsonPath)) {
+        Write-Host "🛠️  No box.json manifest found, generating one from installed modules..." -ForegroundColor Yellow
+        $moduleDirectories = Get-ChildItem -Path $ModulesPath -Directory -ErrorAction SilentlyContinue
         foreach ($moduleDir in $moduleDirectories) {
             $moduleName = $moduleDir.Name
-            $boxJsonPath = Join-Path $moduleDir.FullName "box.json"
-
-            if (Test-Path $boxJsonPath) {
+            $moduleVersion = "unknown"
+            $moduleBoxJsonPath = Join-Path $moduleDir.FullName "box.json"
+            if (Test-Path $moduleBoxJsonPath) {
                 try {
-                    $boxJson = Get-Content $boxJsonPath | ConvertFrom-Json
-                    $version = $boxJson.version
-                    if ($version) {
-                        Write-Host "✓ $moduleName ($version)" -ForegroundColor Green
-                    } else {
-                        Write-Host "✓ $moduleName (version unknown)" -ForegroundColor Green
-                    }
-                } catch {
-                    Write-Host "✓ $moduleName (version unknown)" -ForegroundColor Green
-                }
-            } else {
-                Write-Host "✓ $moduleName (no box.json)" -ForegroundColor Green
+                    $moduleBoxJson = Get-Content $moduleBoxJsonPath -Raw | ConvertFrom-Json
+                    if ($moduleBoxJson.version) { $moduleVersion = $moduleBoxJson.version }
+                } catch { }
             }
+            Set-BoxJsonDependency $boxJsonPath $moduleName $moduleVersion
+        }
+        # Ensure the manifest exists even if there were no module directories to backfill
+        if (-not (Test-Path $boxJsonPath)) {
+            '{"dependencies": {}}' | Set-Content -Path $boxJsonPath
+        }
+    }
+
+    # Read installed modules from the manifest
+    $dependencies = $null
+    if (Test-Path $boxJsonPath) {
+        try {
+            $manifest = Get-Content $boxJsonPath -Raw | ConvertFrom-Json
+            if ($manifest.dependencies) { $dependencies = $manifest.dependencies }
+        } catch { }
+    }
+
+    $depCount = 0
+    if ($dependencies) { $depCount = ($dependencies.PSObject.Properties | Measure-Object).Count }
+
+    if ($depCount -eq 0) {
+        Write-Host "📭 No modules installed" -ForegroundColor Yellow
+    } else {
+        foreach ($prop in $dependencies.PSObject.Properties) {
+            Write-Host "✓ $($prop.Name) ($($prop.Value))" -ForegroundColor Green
         }
     }
 }
@@ -508,6 +555,9 @@ boxlang module:$moduleName %*
             }
         }
 
+        # Track this install in the modules manifest
+        Set-BoxJsonDependency (Join-Path $MODULES_HOME "box.json") $targetModule $targetVersion
+
         # Success message
         Write-Host ""
         Write-Host "✅ BoxLang® Module [$targetModule@$targetVersion] installed successfully!" -ForegroundColor Green
@@ -578,6 +628,8 @@ function Remove-Module {
     try {
         Remove-Item -Path $modulePath -Recurse -Force
         Write-Host "✅ Module '$ModuleName' removed successfully!" -ForegroundColor Green
+        # Untrack this module from the modules manifest
+        Remove-BoxJsonDependency (Join-Path $MODULES_HOME "box.json") $ModuleName
     } catch {
         Write-Host "❌ Error: Failed to remove module '$ModuleName': $($_.Exception.Message)" -ForegroundColor Red
         exit 1

--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -629,8 +629,8 @@ function Install-Module {
     } else {
         # We have a targeted version, first try to get it from ForgeBox API to check for forgeboxStorage
         try {
-            $versionJson = Invoke-RestMethod -Uri "$FORGEBOX_API_URL/entry/$targetModule/$targetVersion" -ErrorAction Stop
-            if ($versionJson -and $versionJson.data) {
+            $versionJson = Invoke-RestMethod -Uri "$FORGEBOX_API_URL/entry/$targetModule/versions/$targetVersion" -ErrorAction Stop
+            if ($versionJson -and $versionJson.data -and $versionJson.data.downloadURL) {
                 $downloadUrlTemp = $versionJson.data.downloadURL
                 if ($downloadUrlTemp -eq "forgeboxStorage") {
                     $downloadUrl = Resolve-ForgeboxStorageUrl $targetModule $targetVersion

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -107,6 +107,7 @@ show_help() {
 list_modules() {
 	local MODULES_PATH=${1}
 	local LOCATION_DESC=${2}
+	local BOX_JSON_PATH="${MODULES_PATH}/box.json"
 
 	printf "${YELLOW}📋 Installed BoxLang Modules (${LOCATION_DESC}):${NORMAL}\n"
 
@@ -116,28 +117,37 @@ list_modules() {
 		return 0
 	fi
 
-	# List all directories in the modules folder
-	if [ -z "$(ls -A "${MODULES_PATH}" 2>/dev/null)" ]; then
-		printf "${YELLOW}📭 No modules installed${NORMAL}\n"
-	else
-		# List modules with version information from box.json
+	# Backfill: generate the manifest from installed modules if it doesn't exist yet
+	# (e.g. modules installed before this feature existed, or by an older script version)
+	if [ ! -f "${BOX_JSON_PATH}" ]; then
+		printf "${YELLOW}🛠️  No box.json manifest found, generating one from installed modules...${NORMAL}\n"
 		for module_dir in "${MODULES_PATH}"/*; do
 			if [ -d "$module_dir" ]; then
+				local module_name module_version module_box_json
 				module_name=$(basename "$module_dir")
-				box_json_path="$module_dir/box.json"
-
-				if [ -f "$box_json_path" ]; then
-					# Extract version from box.json
-					version=$(jq -r '.version // "unknown"' "$box_json_path" 2>/dev/null)
-					if [ "$version" != "null" ] && [ -n "$version" ]; then
-						printf -- "✓ %s (%s)\n" "$module_name" "$version"
-					else
-						printf -- "✓ %s (version unknown)\n" "$module_name"
-					fi
-				else
-					printf -- "✓ %s (no box.json)\n" "$module_name"
+				module_box_json="$module_dir/box.json"
+				module_version="unknown"
+				if [ -f "$module_box_json" ]; then
+					module_version=$(jq -r '.version // "unknown"' "$module_box_json" 2>/dev/null)
+					[ "$module_version" = "null" ] && module_version="unknown"
 				fi
+				box_json_set_dependency "${BOX_JSON_PATH}" "${module_name}" "${module_version}"
 			fi
+		done
+		# Ensure the manifest exists even if there were no module directories to backfill
+		[ -f "${BOX_JSON_PATH}" ] || echo '{"dependencies": {}}' > "${BOX_JSON_PATH}"
+	fi
+
+	# Read installed modules from the manifest
+	local DEP_COUNT
+	DEP_COUNT=$(jq -r '.dependencies // {} | length' "${BOX_JSON_PATH}" 2>/dev/null)
+
+	if [ -z "$DEP_COUNT" ] || [ "$DEP_COUNT" -eq 0 ]; then
+		printf "${YELLOW}📭 No modules installed${NORMAL}\n"
+	else
+		jq -r '.dependencies // {} | to_entries[] | "\(.key)\t\(.value)"' "${BOX_JSON_PATH}" 2>/dev/null |
+		while IFS=$'\t' read -r module_name module_version; do
+			printf -- "✓ %s (%s)\n" "$module_name" "$module_version"
 		done
 	fi
 }
@@ -470,6 +480,9 @@ EOF
 			fi
 		fi
 	fi
+	# Track this install in the modules manifest
+	box_json_set_dependency "${MODULES_HOME}/box.json" "${TARGET_MODULE}" "${TARGET_VERSION}"
+
 	# Success message
 	printf "${GREEN}✅ BoxLang® Module [${TARGET_MODULE}@${TARGET_VERSION}] installed!${NORMAL}\n"
 }
@@ -528,9 +541,56 @@ remove_module() {
 	printf "${BLUE}🗑️  Removing module ${MODULE_NAME}...${NORMAL}\n"
 	if rm -rf "${MODULE_PATH}"; then
 		printf "${GREEN}✅ Module '${MODULE_NAME}' removed successfully!${NORMAL}\n"
+		# Untrack this module from the modules manifest
+		box_json_remove_dependency "${MODULES_HOME}/box.json" "${MODULE_NAME}"
 	else
 		printf "${RED}❌ Error: Failed to remove module '${MODULE_NAME}'${NORMAL}\n"
 		exit 1
+	fi
+}
+
+###########################################################################
+# box.json Manifest Helpers
+###########################################################################
+
+# Set (add or update) a dependency entry in the modules manifest box.json.
+# Creates the file (and/or the dependencies struct) if it doesn't already exist.
+box_json_set_dependency() {
+	local BOX_JSON_PATH=${1}
+	local MODULE_NAME=${2}
+	local MODULE_VERSION=${3}
+
+	[ -f "${BOX_JSON_PATH}" ] || echo '{}' > "${BOX_JSON_PATH}"
+
+	local TMP_FILE
+	TMP_FILE=$(mktemp)
+	if jq --arg name "${MODULE_NAME}" --arg version "${MODULE_VERSION}" \
+		'.dependencies = ((.dependencies // {}) + {($name): $version})' \
+		"${BOX_JSON_PATH}" > "${TMP_FILE}"; then
+		mv "${TMP_FILE}" "${BOX_JSON_PATH}"
+	else
+		rm -f "${TMP_FILE}"
+		printf "${YELLOW}⚠️  Warning: Failed to update box.json dependencies${NORMAL}\n"
+	fi
+}
+
+# Remove a dependency entry from the modules manifest box.json.
+# Creates the file (and/or the dependencies struct) if it doesn't already exist.
+box_json_remove_dependency() {
+	local BOX_JSON_PATH=${1}
+	local MODULE_NAME=${2}
+
+	[ -f "${BOX_JSON_PATH}" ] || echo '{}' > "${BOX_JSON_PATH}"
+
+	local TMP_FILE
+	TMP_FILE=$(mktemp)
+	if jq --arg name "${MODULE_NAME}" \
+		'.dependencies = (.dependencies // {}) | del(.dependencies[$name])' \
+		"${BOX_JSON_PATH}" > "${TMP_FILE}"; then
+		mv "${TMP_FILE}" "${BOX_JSON_PATH}"
+	else
+		rm -f "${TMP_FILE}"
+		printf "${YELLOW}⚠️  Warning: Failed to update box.json dependencies${NORMAL}\n"
 	fi
 }
 

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -347,14 +347,17 @@ install_module() {
 		local DOWNLOAD_URL="$DOWNLOAD_URL"
 	else
 		# We have a targeted version, first try to get it from ForgeBox API to check for forgeboxStorage
-		local VERSION_JSON=$(curl -sSL "${FORGEBOX_API_URL}/entry/${TARGET_MODULE}/${TARGET_VERSION}")
+		local VERSION_JSON=$(curl -sSL "${FORGEBOX_API_URL}/entry/${TARGET_MODULE}/versions/${TARGET_VERSION}")
 		if [ -n "$VERSION_JSON" ] && [ "$VERSION_JSON" != "null" ]; then
 			local DOWNLOAD_URL_TEMP=$(echo "${VERSION_JSON}" | jq -r '.data.downloadURL')
 			if [ "$DOWNLOAD_URL_TEMP" = "forgeboxStorage" ]; then
 				local DOWNLOAD_URL=$(resolve_forgebox_storage_url "$TARGET_MODULE" "$TARGET_VERSION")
-			else
+			elif [ "$DOWNLOAD_URL_TEMP" != "null" ] && [ -n "$DOWNLOAD_URL_TEMP" ]; then
 				# Use the download URL from API if available
 				local DOWNLOAD_URL="$DOWNLOAD_URL_TEMP"
+			else
+				# Fallback: build the download URL from the artifacts directly
+				local DOWNLOAD_URL="https://downloads.ortussolutions.com/ortussolutions/boxlang-modules/${TARGET_MODULE}/${TARGET_VERSION}/${TARGET_MODULE}-${TARGET_VERSION}.zip"
 			fi
 		else
 			# Fallback: build the download URL from the artifacts directly

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -74,6 +74,8 @@ show_help() {
 	printf "  install-bx-module.sh <module-name>[@<version>] [<module-name>[@<version>] ...] [--local]\n"
 	printf "  install-bx-module.sh --remove <module-name> [<module-name> ...] [--force] [--local]\n"
 	printf "  install-bx-module.sh --list [--local]\n"
+	printf "  install-bx-module.sh --outdated [--local]\n"
+	printf "  install-bx-module.sh --update [--force] [--local]\n"
 	printf "  install-bx-module.sh --help\n\n"
 	printf "${BOLD}ARGUMENTS:${NORMAL}\n"
 	printf "  <module-name>     The name(s) of the module(s) to install. (Comma or space delimmited)\n"
@@ -81,8 +83,10 @@ show_help() {
 	printf "${BOLD}OPTIONS:${NORMAL}\n"
 	printf "  --local           Install to/remove from local boxlang_modules folder instead of BoxLang HOME. The BoxLang HOME is the default.\n"
 	printf "  --remove          Remove specified module(s)\n"
-	printf "  --force           Skip confirmation when removing modules(s)(use with --remove)\n"
+	printf "  --force           Skip confirmation when removing or updating module(s) (use with --remove or --update)\n"
 	printf "  --list            Show installed module(s)\n"
+	printf "  --outdated        Check installed modules against FORGEBOX and report which are outdated\n"
+	printf "  --update          Update all outdated module(s) to their latest FORGEBOX version\n"
 	printf "  --help, -h        Show this help message\n\n"
 	printf "${BOLD}EXAMPLES:${NORMAL}\n"
 	printf "  install-bx-module bx-orm\n"
@@ -94,7 +98,11 @@ show_help() {
 	printf "  install-bx-module --remove bx-orm,bx-ai --force\n"
 	printf "  install-bx-module --remove \"bx-orm, bx-ai\" --local\n"
 	printf "  install-bx-module --list\n"
-	printf "  install-bx-module --list --local\n\n"
+	printf "  install-bx-module --list --local\n"
+	printf "  install-bx-module --outdated\n"
+	printf "  install-bx-module --outdated --local\n"
+	printf "  install-bx-module --update\n"
+	printf "  install-bx-module --update --force --local\n\n"
 	printf "${BOLD}NOTES:${NORMAL}\n"
 	printf "  - If no version is specified, the latest version from FORGEBOX will be installed\n"
 	printf "  - Multiple modules can be specified, separated by spaces or commas\n"
@@ -107,7 +115,7 @@ show_help() {
 list_modules() {
 	local MODULES_PATH=${1}
 	local LOCATION_DESC=${2}
-	local BOX_JSON_PATH="${MODULES_PATH}/box.json"
+	local BOX_JSON_PATH
 
 	printf "${YELLOW}📋 Installed BoxLang Modules (${LOCATION_DESC}):${NORMAL}\n"
 
@@ -117,26 +125,7 @@ list_modules() {
 		return 0
 	fi
 
-	# Backfill: generate the manifest from installed modules if it doesn't exist yet
-	# (e.g. modules installed before this feature existed, or by an older script version)
-	if [ ! -f "${BOX_JSON_PATH}" ]; then
-		printf "${YELLOW}🛠️  No box.json manifest found, generating one from installed modules...${NORMAL}\n"
-		for module_dir in "${MODULES_PATH}"/*; do
-			if [ -d "$module_dir" ]; then
-				local module_name module_version module_box_json
-				module_name=$(basename "$module_dir")
-				module_box_json="$module_dir/box.json"
-				module_version="unknown"
-				if [ -f "$module_box_json" ]; then
-					module_version=$(jq -r '.version // "unknown"' "$module_box_json" 2>/dev/null)
-					[ "$module_version" = "null" ] && module_version="unknown"
-				fi
-				box_json_set_dependency "${BOX_JSON_PATH}" "${module_name}" "${module_version}"
-			fi
-		done
-		# Ensure the manifest exists even if there were no module directories to backfill
-		[ -f "${BOX_JSON_PATH}" ] || echo '{"dependencies": {}}' > "${BOX_JSON_PATH}"
-	fi
+	BOX_JSON_PATH=$(ensure_modules_manifest "${MODULES_PATH}")
 
 	# Read installed modules from the manifest
 	local DEP_COUNT
@@ -570,7 +559,7 @@ box_json_set_dependency() {
 		mv "${TMP_FILE}" "${BOX_JSON_PATH}"
 	else
 		rm -f "${TMP_FILE}"
-		printf "${YELLOW}⚠️  Warning: Failed to update box.json dependencies${NORMAL}\n"
+		printf "${YELLOW}⚠️  Warning: Failed to update box.json dependencies${NORMAL}\n" >&2
 	fi
 }
 
@@ -590,8 +579,224 @@ box_json_remove_dependency() {
 		mv "${TMP_FILE}" "${BOX_JSON_PATH}"
 	else
 		rm -f "${TMP_FILE}"
-		printf "${YELLOW}⚠️  Warning: Failed to update box.json dependencies${NORMAL}\n"
+		printf "${YELLOW}⚠️  Warning: Failed to update box.json dependencies${NORMAL}\n" >&2
 	fi
+}
+
+# Ensures ${MODULES_PATH}/box.json exists (backfilling it from installed module directories
+# if missing), and prints its path.
+ensure_modules_manifest() {
+	local MODULES_PATH=${1}
+	local BOX_JSON_PATH="${MODULES_PATH}/box.json"
+
+	if [ ! -f "${BOX_JSON_PATH}" ]; then
+		printf "${YELLOW}🛠️  No box.json manifest found, generating one from installed modules...${NORMAL}\n" >&2
+		for module_dir in "${MODULES_PATH}"/*; do
+			if [ -d "$module_dir" ]; then
+				local module_name module_version module_box_json
+				module_name=$(basename "$module_dir")
+				module_box_json="$module_dir/box.json"
+				module_version="unknown"
+				if [ -f "$module_box_json" ]; then
+					module_version=$(jq -r '.version // "unknown"' "$module_box_json" 2>/dev/null)
+					[ "$module_version" = "null" ] && module_version="unknown"
+				fi
+				box_json_set_dependency "${BOX_JSON_PATH}" "${module_name}" "${module_version}"
+			fi
+		done
+		# Ensure the manifest exists even if there were no module directories to backfill
+		[ -f "${BOX_JSON_PATH}" ] || echo '{"dependencies": {}}' > "${BOX_JSON_PATH}"
+	fi
+
+	echo "${BOX_JSON_PATH}"
+}
+
+###########################################################################
+# Outdated / Update Helpers
+###########################################################################
+
+# Lean ForgeBox "latest version" lookup (no progress messages, no download URL resolution).
+fetch_forgebox_latest_version() {
+	local MODULE_NAME=${1}
+	local ENTRY_JSON
+	ENTRY_JSON=$(curl -sSL "${FORGEBOX_API_URL}/entry/${MODULE_NAME}/latest" 2>/dev/null)
+	if [ -z "$ENTRY_JSON" ] || [ "$ENTRY_JSON" = "null" ]; then
+		return 1
+	fi
+
+	local VERSION
+	VERSION=$(echo "${ENTRY_JSON}" | jq -r '.data.version // empty' 2>/dev/null)
+	if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+		return 1
+	fi
+
+	echo "$VERSION"
+}
+
+# Emits one tab-separated line per dependency: name<TAB>current<TAB>latest<TAB>status
+# status is one of: uptodate, ahead, outdated, unreachable
+# Dependencies whose current version isn't a parseable semver are skipped entirely.
+compute_outdated_report() {
+	local MODULES_PATH=${1}
+	local BOX_JSON_PATH
+	BOX_JSON_PATH=$(ensure_modules_manifest "${MODULES_PATH}")
+
+	jq -r '.dependencies // {} | to_entries[] | "\(.key)\t\(.value)"' "${BOX_JSON_PATH}" 2>/dev/null |
+	while IFS=$'\t' read -r module_name current_version; do
+		local current_semver
+		current_semver=$(extract_semantic_version "$current_version")
+		[ -z "$current_semver" ] && continue
+
+		local latest_version status latest_semver
+		# `|| true` keeps a failed lookup (e.g. module removed from FORGEBOX, network
+		# hiccup) from tripping `set -e` and silently truncating the rest of the report.
+		latest_version=$(fetch_forgebox_latest_version "$module_name") || true
+		if [ -z "$latest_version" ]; then
+			status="unreachable"
+			latest_version="?"
+		else
+			latest_semver=$(extract_semantic_version "$latest_version")
+			if [ -z "$latest_semver" ]; then
+				status="unreachable"
+			else
+				local cmp_result
+				compare_versions "$current_semver" "$latest_semver" && cmp_result=0 || cmp_result=$?
+				case "$cmp_result" in
+					0) status="uptodate" ;;
+					1) status="ahead" ;;
+					2) status="outdated" ;;
+				esac
+			fi
+		fi
+		printf '%s\t%s\t%s\t%s\n' "$module_name" "$current_version" "$latest_version" "$status"
+	done
+}
+
+outdated_modules() {
+	local MODULES_HOME=${1}
+	local LOCATION_DESC=${2}
+
+	printf "${YELLOW}🔎 Checking for outdated BoxLang Modules (${LOCATION_DESC}):${NORMAL}\n\n"
+
+	if [ ! -d "${MODULES_HOME}" ]; then
+		printf "${YELLOW}📂 No modules directory found at ${MODULES_HOME}${NORMAL}\n"
+		return 0
+	fi
+
+	command_exists curl || {
+		printf "${RED}❌ Error: curl is required but not installed${NORMAL}\n"
+		exit 1
+	}
+
+	local REPORT_FILE
+	REPORT_FILE=$(mktemp)
+	compute_outdated_report "${MODULES_HOME}" > "${REPORT_FILE}"
+
+	if [ ! -s "${REPORT_FILE}" ]; then
+		printf "${YELLOW}📭 No modules to report on${NORMAL}\n"
+		rm -f "${REPORT_FILE}"
+		return 0
+	fi
+
+	printf "%-25s %-15s %-15s %s\n" "DEPENDENCY" "CURRENT" "FORGEBOX" "STATUS"
+	printf "%-25s %-15s %-15s %s\n" "-------------------------" "---------------" "---------------" "--------------------"
+
+	local OUTDATED_NAMES=() OUTDATED_VERSIONS=()
+	while IFS=$'\t' read -r module_name current_version latest_version status; do
+		local status_label
+		case "$status" in
+			uptodate) status_label="✅ up to date" ;;
+			ahead) status_label="🔄 ahead (dev/snapshot)" ;;
+			outdated)
+				status_label="🆙 outdated"
+				OUTDATED_NAMES+=("$module_name")
+				OUTDATED_VERSIONS+=("$latest_version")
+				;;
+			*) status_label="⚠️  unable to check" ;;
+		esac
+		printf "%-25s %-15s %-15s %s\n" "$module_name" "$current_version" "$latest_version" "$status_label"
+	done < "${REPORT_FILE}"
+	rm -f "${REPORT_FILE}"
+
+	printf "\n"
+	local OUTDATED_COUNT=${#OUTDATED_NAMES[@]}
+	if [ "$OUTDATED_COUNT" -eq 0 ]; then
+		printf "${GREEN}✅ All modules are up to date${NORMAL}\n"
+		return 0
+	fi
+
+	printf "${YELLOW}⚠️  %d module(s) outdated${NORMAL}\n" "$OUTDATED_COUNT"
+	printf "${RED}⬆️  Would you like to update ${OUTDATED_COUNT} outdated module(s) now? [y/N]: ${NORMAL}"
+	read -r confirmation < /dev/tty
+	case "$confirmation" in
+		[yY]|[yY][eE][sS])
+			local i
+			for (( i=0; i<OUTDATED_COUNT; i++ )); do
+				install_module "${OUTDATED_NAMES[$i]}@${OUTDATED_VERSIONS[$i]}"
+			done
+			;;
+		*)
+			printf "${YELLOW}Skipping updates.${NORMAL}\n"
+			;;
+	esac
+}
+
+update_modules() {
+	local MODULES_HOME=${1}
+	local LOCATION_DESC=${2}
+	local FORCE_UPDATE=${3:-false}
+
+	printf "${YELLOW}🔎 Checking for outdated BoxLang Modules (${LOCATION_DESC}):${NORMAL}\n\n"
+
+	if [ ! -d "${MODULES_HOME}" ]; then
+		printf "${YELLOW}📂 No modules directory found at ${MODULES_HOME}${NORMAL}\n"
+		return 0
+	fi
+
+	command_exists curl || {
+		printf "${RED}❌ Error: curl is required but not installed${NORMAL}\n"
+		exit 1
+	}
+
+	local REPORT_FILE
+	REPORT_FILE=$(mktemp)
+	compute_outdated_report "${MODULES_HOME}" > "${REPORT_FILE}"
+
+	local OUTDATED_NAMES=() OUTDATED_VERSIONS=()
+	while IFS=$'\t' read -r module_name current_version latest_version status; do
+		if [ "$status" = "outdated" ]; then
+			printf -- "🆙 %s: %s → %s\n" "$module_name" "$current_version" "$latest_version"
+			OUTDATED_NAMES+=("$module_name")
+			OUTDATED_VERSIONS+=("$latest_version")
+		fi
+	done < "${REPORT_FILE}"
+	rm -f "${REPORT_FILE}"
+
+	local OUTDATED_COUNT=${#OUTDATED_NAMES[@]}
+	if [ "$OUTDATED_COUNT" -eq 0 ]; then
+		printf "${GREEN}✅ All modules are up to date, nothing to update${NORMAL}\n"
+		return 0
+	fi
+
+	printf "\n"
+	if [ "$FORCE_UPDATE" != "true" ]; then
+		printf "${RED}⬆️  Update ${OUTDATED_COUNT} outdated module(s)? [y/N]: ${NORMAL}"
+		read -r confirmation < /dev/tty
+		case "$confirmation" in
+			[yY]|[yY][eE][sS]) ;;
+			*)
+				printf "${YELLOW}❌ Update cancelled${NORMAL}\n"
+				return 0
+				;;
+		esac
+	fi
+
+	local i
+	for (( i=0; i<OUTDATED_COUNT; i++ )); do
+		install_module "${OUTDATED_NAMES[$i]}@${OUTDATED_VERSIONS[$i]}"
+	done
+
+	printf "${GREEN}✅ Updated ${OUTDATED_COUNT} module(s)!${NORMAL}\n"
 }
 
 main() {
@@ -644,6 +849,88 @@ main() {
 		fi
 
 		list_modules "$MODULES_PATH" "$LOCATION_DESC"
+		exit 0
+	fi
+
+	# Handle --outdated command (can be used with --local)
+	if [ "$1" = "--outdated" ]; then
+		shift # Remove --outdated from arguments
+
+		OUTDATED_LOCAL=false
+		if [ "$1" = "--local" ]; then
+			OUTDATED_LOCAL=true
+			shift # Remove --local from arguments
+		fi
+
+		# Ensure no other arguments after --outdated [--local]
+		if [ $# -gt 0 ]; then
+			printf "${RED}❌ Error: --outdated command does not accept additional arguments${NORMAL}\n"
+			printf "${YELLOW}💡 Usage: install-bx-module.sh --outdated [--local]${NORMAL}\n"
+			exit 1
+		fi
+
+		LOCAL_INSTALL=$OUTDATED_LOCAL
+		if [ "$OUTDATED_LOCAL" = true ]; then
+			MODULES_HOME="$(pwd)/boxlang_modules"
+			LOCATION_DESC="Local - $(pwd)/boxlang_modules"
+		else
+			if [ -z "${BOXLANG_HOME}" ]; then
+				export BOXLANG_HOME="$HOME/.boxlang"
+			fi
+			MODULES_HOME="${BOXLANG_HOME}/modules"
+			LOCATION_DESC="Global - ${BOXLANG_HOME}/modules"
+		fi
+
+		outdated_modules "$MODULES_HOME" "$LOCATION_DESC"
+		exit 0
+	fi
+
+	# Handle --update command (can be used with --force and --local, in any order)
+	if [ "$1" = "--update" ]; then
+		shift # Remove --update from arguments
+
+		FORCE_UPDATE=false
+		for arg in "$@"; do
+			if [ "$arg" = "--force" ]; then
+				FORCE_UPDATE=true
+				break
+			fi
+		done
+		if [ "$FORCE_UPDATE" = true ]; then
+			set -- $(printf '%s\n' "$@" | grep -v '^--force$')
+		fi
+
+		UPDATE_LOCAL=false
+		for arg in "$@"; do
+			if [ "$arg" = "--local" ]; then
+				UPDATE_LOCAL=true
+				break
+			fi
+		done
+		if [ "$UPDATE_LOCAL" = true ]; then
+			set -- $(printf '%s\n' "$@" | grep -v '^--local$')
+		fi
+
+		# Ensure no other arguments remain
+		if [ $# -gt 0 ]; then
+			printf "${RED}❌ Error: --update command does not accept additional arguments${NORMAL}\n"
+			printf "${YELLOW}💡 Usage: install-bx-module.sh --update [--force] [--local]${NORMAL}\n"
+			exit 1
+		fi
+
+		LOCAL_INSTALL=$UPDATE_LOCAL
+		if [ "$UPDATE_LOCAL" = true ]; then
+			MODULES_HOME="$(pwd)/boxlang_modules"
+			LOCATION_DESC="Local - $(pwd)/boxlang_modules"
+		else
+			if [ -z "${BOXLANG_HOME}" ]; then
+				export BOXLANG_HOME="$HOME/.boxlang"
+			fi
+			MODULES_HOME="${BOXLANG_HOME}/modules"
+			LOCATION_DESC="Global - ${BOXLANG_HOME}/modules"
+		fi
+
+		update_modules "$MODULES_HOME" "$LOCATION_DESC" "$FORCE_UPDATE"
 		exit 0
 	fi
 


### PR DESCRIPTION
install-bx-module now maintains a box.json (dependencies: {}) inside the
modules folder (boxlang_modules/ for --local, $BOXLANG_HOME/modules
otherwise). Installing a module writes/updates its resolved version under
dependencies, removing a module deletes its entry, and --list now reads
from this manifest instead of re-deriving state from each module's own
box.json. If no manifest exists yet (e.g. modules installed before this
change), --list backfills one by scanning the installed module
directories.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GFYuMDsgdCg9qdUzYidU8G