### PR TITLE
Simplify install-boxlang and install-bvm UI to match pi installer style

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,54 +205,39 @@ C:\BoxLang\  # Installation directory (Windows)
 Always make sure to run the `--help` command to get the latest and greatest command usage.
 
 ```bash
-📦 BoxLang® Quick Installer v@build.version@
-
-This script installs the BoxLang® runtime, MiniServer and tools on your system.
+BoxLang® Quick Installer v@build.version@
+Installs the BoxLang® runtime, MiniServer, and tools.
 
 Usage:
   install-boxlang [version] [options]
-  install-boxlang --help
 
 Arguments:
-  [version]         (Optional) Specify which version to install
-                    - 'latest' (default): Install the latest stable release
-                    - 'snapshot': Install the latest development snapshot
-                    - '1.2.0': Install a specific version number
+  [version]              'latest' (default), 'snapshot', or a specific version like '1.2.0'
 
 Options:
-  --help, -h            Show this help message
-  --uninstall           Remove BoxLang from the system
-  --check-update        Check if a newer version is available
-  --system              Force system-wide installation (requires sudo)
-  --force               Force reinstallation even if already installed
-  --with-commandbox     Install CommandBox without prompting
-  --without-commandbox  Skip CommandBox installation
-  --with-jre            ✨ Automatically install Java 21 JRE if not found
-  --without-jre         ✨ Skip Java installation (manual installation required)
-  --yes, -y             Use defaults for all prompts (installs CommandBox and Java)
+  --help, -h             Show this help message
+  --uninstall            Remove BoxLang from the system
+  --check-update         Check if a newer version is available
+  --system               Force system-wide installation (requires sudo)
+  --force                Force reinstallation even if already installed
+  --with-commandbox      Install CommandBox without prompting
+  --without-commandbox   Skip CommandBox installation
+  --with-jre             Automatically install Java 21 JRE if not found
+  --without-jre          Skip Java installation (manual installation required)
+  --yes, -y              Use defaults for all prompts (installs CommandBox and Java)
 
 Examples:
   install-boxlang
-  install-boxlang latest
   install-boxlang snapshot
-  install-boxlang 1.2.0
-  install-boxlang --force
-  install-boxlang --with-commandbox
-  install-boxlang --without-commandbox
-  install-boxlang --with-jre
-  install-boxlang --without-jre
-  install-boxlang --with-commandbox --with-jre
+  install-boxlang 1.2.0 --force
   install-boxlang --yes
   install-boxlang --uninstall
   install-boxlang --check-update
   sudo install-boxlang --system
 
-Non-Interactive Usage:
-  🌐 Install with CommandBox: curl -fsSL https://boxlang.io/install.sh | bash -s -- --with-commandbox
-  🌐 Install without CommandBox: curl -fsSL https://boxlang.io/install.sh | bash -s -- --without-commandbox
-  🌐 Install with Java auto-install: curl -fsSL https://boxlang.io/install.sh | bash -s -- --with-jre
-  🌐 Full auto-install (Java + CommandBox): curl -fsSL https://boxlang.io/install.sh | bash -s -- --yes
-  🌐 Install with defaults: curl -fsSL https://boxlang.io/install.sh | bash -s -- --yes
+Non-interactive:
+  curl -fsSL https://boxlang.io/install.sh | bash -s -- --yes
+  curl -fsSL https://boxlang.io/install.sh | bash -s -- --with-jre --with-commandbox
 ```
 
 ## 🎯 Detailed Usage

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ C:\BoxLang\  # Installation directory (Windows)
 Always make sure to run the `--help` command to get the latest and greatest command usage.
 
 ```bash
-BoxLang® Quick Installer v@build.version@
+📦 BoxLang® Quick Installer v@build.version@
 Installs the BoxLang® runtime, MiniServer, and tools.
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Options:
   --with-jre             Automatically install Java 21 JRE if not found
   --without-jre          Skip Java installation (manual installation required)
   --yes, -y              Use defaults for all prompts (installs CommandBox and Java)
+  --verbose, -v          Show every step instead of the progress indicator
 
 Examples:
   install-boxlang

--- a/src/helpers/helpers.sh
+++ b/src/helpers/helpers.sh
@@ -11,23 +11,23 @@
 ###########################################################################
 
 print_info() {
-    printf "${BLUE}ℹ️  $1${NORMAL}\n"
+    printf "%s\n" "$1"
 }
 
 print_success() {
-    printf "${GREEN}✅ $1${NORMAL}\n"
+    printf "${GREEN}✓${NORMAL} %s\n" "$1"
 }
 
 print_warning() {
-    printf "${YELLOW}⚠️  $1${NORMAL}\n"
+    printf "${YELLOW}%s${NORMAL}\n" "$1"
 }
 
 print_error() {
-    printf "${RED}🔴  $1${NORMAL}\n"
+    printf "${RED}✗ %s${NORMAL}\n" "$1" >&2
 }
 
 print_header() {
-    printf "${BOLD}${CYAN}$1${NORMAL}\n"
+    printf "${BOLD}%s${NORMAL}\n" "$1"
 }
 
 ###########################################################################
@@ -78,16 +78,16 @@ setup_colors() {
 # Verifies required dependencies are installed: curl, unzip and jq
 preflight_check() {
 	local auto_install="${1:-false}"
-	printf "${BLUE}🔍 Running system requirements checks...${NORMAL}\n"
+	print_info "Checking system requirements..."
 	local missing_deps=()
 
 	# Check required commands dependencies
 	if [ "$(uname)" = "Darwin" ]; then
 		# If brew is not installed, then quit, but only if we are on macOS
 		if ! command_exists brew; then
-			printf "${RED}❌ Homebrew is not installed. Please install Homebrew first.${NORMAL}\n"
-			printf "${BLUE}💡 You can install Homebrew with:${NORMAL}\n"
-			printf "${GREEN}   /bin/bash -c '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'\n"
+			print_error "Homebrew is not installed. Please install Homebrew first."
+			printf "Install it with:\n"
+			printf "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"\n"
 			return 1
 		fi
 	fi
@@ -97,80 +97,73 @@ preflight_check() {
 	command_exists jq || missing_deps+=( "jq" )
 
 	if [ ${#missing_deps[@]} -ne 0 ]; then
-		printf "${RED}❌ Missing required dependencies: ${missing_deps[*]}${NORMAL}\n"
+		print_warning "Missing required dependencies: ${missing_deps[*]}"
 
 		if [ "$(uname)" = "Darwin" ]; then
 			# Install the dependencies using Homebrew
-			printf "${BLUE}💡 Installing missing dependencies using Homebrew...${NORMAL}\n"
+			print_info "Installing missing dependencies with Homebrew..."
 			for dep in "${missing_deps[@]}"; do
-				printf "${BLUE}   Installing ${dep}...${NORMAL}\n"
+				print_info "Installing ${dep}..."
 				if ! brew install "$dep"; then
-					printf "${RED}❌ Failed to install ${dep}. Please install it manually.${NORMAL}\n"
+					print_error "Failed to install ${dep}. Please install it manually."
 					return 1
 				fi
 			done
-			printf "${GREEN}✅ All dependencies installed successfully!${NORMAL}\n"
+			print_success "All dependencies installed"
 		elif [ "$(uname)" = "Linux" ]; then
-			printf "${BLUE}💡 Installing missing dependencies using system package manager...${NORMAL}\n"
+			print_info "Installing missing dependencies with the system package manager..."
 
 			# Determine if we need sudo based on current user privileges
 			local use_sudo=""
 			if [ "$EUID" -ne 0 ]; then
 				use_sudo="sudo"
-				printf "${BLUE}🔐 Running as user (EUID=$EUID), will use sudo${NORMAL}\n"
-			else
-				printf "${BLUE}👑 Running as root (EUID=$EUID), no sudo needed${NORMAL}\n"
 			fi
 
 			if command_exists apt-get; then
-				printf "${BLUE}   Updating package list...${NORMAL}\n"
-				printf "${BLUE}🔍 Executing: $use_sudo apt update${NORMAL}\n"
+				print_info "Updating package list..."
 				if ! $use_sudo apt update; then
-					printf "${RED}❌ Failed to update package list with apt.${NORMAL}\n"
+					print_error "Failed to update package list with apt."
 					return 1
 				fi
-				printf "${BLUE}   Installing dependencies: ${missing_deps[*]}...${NORMAL}\n"
-				printf "${BLUE}🔍 Executing: $use_sudo apt install -y ${missing_deps[*]}${NORMAL}\n"
+				print_info "Installing dependencies: ${missing_deps[*]}..."
 				if ! $use_sudo apt install -y ${missing_deps[*]}; then
-					printf "${RED}❌ Failed to install dependencies with apt. Please install them manually.${NORMAL}\n"
+					print_error "Failed to install dependencies with apt. Please install them manually."
 					return 1
 				fi
 			elif command_exists apk; then
-				printf "${BLUE}   Updating package list...${NORMAL}\n"
-				printf "${BLUE}🔍 Executing: $use_sudo apk update${NORMAL}\n"
+				print_info "Updating package list..."
 				if ! $use_sudo apk update; then
-					printf "${RED}❌ Failed to update package list with apk.${NORMAL}\n"
+					print_error "Failed to update package list with apk."
 					return 1
 				fi
-				printf "${BLUE}   Installing dependencies: ${missing_deps[*]}...${NORMAL}\n"
-				printf "${BLUE}🔍 Executing: $use_sudo apk add ${missing_deps[*]}${NORMAL}\n"
+				print_info "Installing dependencies: ${missing_deps[*]}..."
 				if ! $use_sudo apk add ${missing_deps[*]}; then
-					printf "${RED}❌ Failed to install dependencies with apk. Please install them manually.${NORMAL}\n"
+					print_error "Failed to install dependencies with apk. Please install them manually."
 					return 1
 				fi
 			elif command_exists yum; then
-				printf "${BLUE}   Installing dependencies with yum...${NORMAL}\n"
+				print_info "Installing dependencies with yum..."
 				if ! $use_sudo yum install -y ${missing_deps[*]}; then
-					printf "${RED}❌ Failed to install dependencies with yum. Please install them manually.${NORMAL}\n"
+					print_error "Failed to install dependencies with yum. Please install them manually."
 					return 1
 				fi
 			elif command_exists dnf; then
-				printf "${BLUE}   Installing dependencies with dnf...${NORMAL}\n"
+				print_info "Installing dependencies with dnf..."
 				if ! $use_sudo dnf install -y ${missing_deps[*]}; then
-					printf "${RED}❌ Failed to install dependencies with dnf. Please install them manually.${NORMAL}\n"
+					print_error "Failed to install dependencies with dnf. Please install them manually."
 					return 1
 				fi
 			elif command_exists pacman; then
-				printf "${BLUE}   Installing dependencies with pacman...${NORMAL}\n"
+				print_info "Installing dependencies with pacman..."
 				if ! $use_sudo pacman -S --noconfirm ${missing_deps[*]}; then
-					printf "${RED}❌ Failed to install dependencies with pacman. Please install them manually.${NORMAL}\n"
+					print_error "Failed to install dependencies with pacman. Please install them manually."
 					return 1
 				fi
 			else
-				printf "${RED}❌ No supported package manager found. Please install dependencies manually: ${missing_deps[*]}${NORMAL}\n"
+				print_error "No supported package manager found. Please install dependencies manually: ${missing_deps[*]}"
 				return 1
 			fi
-			printf "${GREEN}✅ All dependencies installed successfully!${NORMAL}\n"
+			print_success "All dependencies installed"
 		fi
 	fi
 
@@ -178,24 +171,24 @@ preflight_check() {
 	# Java Version Check
 	###########################################################################
 	if ! check_java_version "$auto_install"; then
-		printf "${RED}🔴  Error: Java 21 or higher is required to run BoxLang${NORMAL}\n"
+		print_error "Java 21 or higher is required to run BoxLang"
 
 		# Otherwise, prompt user for manual installation choice
-		printf "${YELLOW}Would you like to automatically install Java 21 JRE? (y/N)${NORMAL} "
+		printf "Install it automatically now? (y/N) "
 		read -r response
 		case "$response" in
 			[yY][eE][sS]|[yY])
-				printf "${BLUE}📥 Proceeding with automatic Java installation...${NORMAL}\n"
+				print_info "Installing Java..."
 				if install_java; then
-					printf "${GREEN}✅ Java installation completed successfully!${NORMAL}\n"
+					print_success "Java installed"
 					return 0
 				else
-					printf "${RED}❌ Automatic Java installation failed.${NORMAL}\n"
+					print_error "Automatic Java installation failed."
 					return 1
 				fi
 				;;
 			*)
-				printf "${YELLOW}💡 You can install Java manually using:${NORMAL}\n"
+				printf "Install Java manually with:\n"
 				if [ "$(uname)" = "Darwin" ]; then
 					printf "   brew install openjdk@21\n"
 					printf "   or download from: https://adoptium.net/\n"
@@ -229,7 +222,7 @@ preflight_check() {
 ###########################################################################
 check_java_version() {
 	local auto_install="${1:-false}"
-	printf "${BLUE}🔍 Checking Java 21 installation...${NORMAL}\n"
+	print_info "Checking for Java 21..."
 	local JAVA_CMD=""
 	local JAVA_VERSION=""
 
@@ -253,7 +246,7 @@ check_java_version() {
 
 	# If running under sudo, try to get the original user's environment
 	if [ -n "${SUDO_USER}" ]; then
-		printf "${YELLOW}🛡️ Detected sudo execution. Checking Java from original user context...${NORMAL}\n"
+		print_info "Detected sudo execution, checking Java from original user context..."
 
 		# Try to get Java from the original user's environment
 		local user_java_cmd=$(sudo -u "${SUDO_USER}" -i bash -c 'command -v java 2>/dev/null' || echo "")
@@ -279,7 +272,7 @@ check_java_version() {
 						JAVA_VERSION=$(extract_java_version "$version_output")
 						if [ -n "$JAVA_VERSION" ] && [ "$JAVA_VERSION" -ge 21 ] 2>/dev/null; then
 							JAVA_CMD="$expanded_path"
-							printf "${GREEN}✅ Found Java ${JAVA_VERSION} at: ${JAVA_CMD}${NORMAL}\n"
+							print_success "Found Java ${JAVA_VERSION} at ${JAVA_CMD}"
 							return 0
 						fi
 					fi
@@ -292,10 +285,10 @@ check_java_version() {
 					JAVA_VERSION=$(extract_java_version "$version_output")
 					if [ -n "$JAVA_VERSION" ] && [ "$JAVA_VERSION" -ge 21 ] 2>/dev/null; then
 						JAVA_CMD="$candidate"
-						printf "${GREEN}✅ Found Java ${JAVA_VERSION} at: ${JAVA_CMD}${NORMAL}\n"
+						print_success "Found Java ${JAVA_VERSION} at ${JAVA_CMD}"
 						return 0
 					elif [ -n "$JAVA_VERSION" ]; then
-						printf "${YELLOW}⚠️  Found Java ${JAVA_VERSION} at ${candidate}, but Java 21+ is required${NORMAL}\n"
+						print_warning "Found Java ${JAVA_VERSION} at ${candidate}, but Java 21+ is required"
 					fi
 				fi
 			fi
@@ -304,12 +297,12 @@ check_java_version() {
 
 	# If auto_install is true, attempt automatic installation
 	if [ "$auto_install" = "true" ]; then
-		printf "${YELLOW}Java 21+ not found. Attempting automatic installation...${NORMAL}\n"
+		print_info "Java 21+ not found, installing automatically..."
 		if install_java; then
-			printf "${GREEN}✅ Java installation completed successfully!${NORMAL}\n"
+			print_success "Java installed"
 			return 0
 		else
-			printf "${RED}❌ Automatic Java installation failed.${NORMAL}\n"
+			print_error "Automatic Java installation failed."
 			return 1
 		fi
 	fi
@@ -331,7 +324,7 @@ install_java() {
 	local JRE_FILENAME=""
 	local JAVA_INSTALL_DIR=""
 
-	printf "${BLUE}☕ Installing Java ${JRE_VERSION} ...${NORMAL}\n"
+	print_info "Installing Java ${JRE_VERSION}..."
 
 	# Normalize architecture names
 	case "$ARCH" in
@@ -368,10 +361,10 @@ install_java() {
 			local LIBC_TYPE="glibc"
 			if [ -f /etc/alpine-release ]; then
 				LIBC_TYPE="musl"
-				printf "${BLUE}🏔️  Detected Alpine Linux (musl libc)${NORMAL}\n"
+				print_info "Detected Alpine Linux (musl libc)"
 			elif command_exists ldd && ldd --version 2>&1 | grep -q musl; then
 				LIBC_TYPE="musl"
-				printf "${BLUE}🔍 Detected musl libc${NORMAL}\n"
+				print_info "Detected musl libc"
 			fi
 
 			# Set JRE URLs based on architecture and libc
@@ -400,28 +393,21 @@ install_java() {
 			;;
 	esac
 
-	printf "%s📍 Detected: %s (%s)%s\n" "${BLUE}" "${OS}" "${ARCH}" "${NORMAL}"
-	printf "📥 JRE URL [%s]\n" "${JRE_URL}"
-	printf "📦 JRE Filename [%s]\n" "${JRE_FILENAME}"
-	printf "📂 Installing to [%s]\n" "${JAVA_INSTALL_DIR}"
-	printf "${NORMAL}\n"
+	print_info "Detected: ${OS} (${ARCH}), installing to ${JAVA_INSTALL_DIR}"
 
 	# Create temporary directory
 	local TEMP_DIR=$(mktemp -d)
 	local DOWNLOAD_PATH="$TEMP_DIR/$JRE_FILENAME"
 
 	# Download JRE
-	printf "${BLUE}📥 Downloading JRE...${NORMAL}\n"
+	print_info "Downloading JRE..."
 	if ! curl -L --progress-bar "$JRE_URL" -o "$DOWNLOAD_PATH"; then
 		print_error "Failed to download JRE"
 		rm -rf "$TEMP_DIR"
 		return 1
 	fi
 
-	printf "${GREEN}✅ Downloaded JRE successfully${NORMAL}\n"
-
 	# Create installation directory (requires elevated privileges on most systems)
-	printf "${BLUE}📁 Creating installation directory: $JAVA_INSTALL_DIR${NORMAL}\n"
 	if [ "$OS" = "Darwin" ] || [ "$OS" = "Linux" ]; then
 		# Check if we need sudo or if running as root
 		local use_sudo=""
@@ -437,7 +423,7 @@ install_java() {
 	fi
 
 	# Extract JRE
-	printf "${BLUE}📦 Extracting JRE...${NORMAL}\n"
+	print_info "Extracting JRE..."
 	if ! tar -xzf "$DOWNLOAD_PATH" -C "$TEMP_DIR"; then
 		print_error "Failed to extract JRE archive"
 		rm -rf "$TEMP_DIR"
@@ -454,12 +440,10 @@ install_java() {
 
 	# Remove existing installation if it exists
 	if [ -d "$JAVA_INSTALL_DIR" ]; then
-		printf "${BLUE}🧹 Removing existing Java installation...${NORMAL}\n"
 		$use_sudo rm -rf "$JAVA_INSTALL_DIR"
 	fi
 
 	# Move extracted content to final location
-	printf "${BLUE}📋 Installing JRE to $JAVA_INSTALL_DIR...${NORMAL}\n"
 	if ! $use_sudo mv "$EXTRACTED_DIR" "$JAVA_INSTALL_DIR"; then
 		print_error "Failed to move JRE to installation directory"
 		rm -rf "$TEMP_DIR"
@@ -477,17 +461,15 @@ install_java() {
 	local PROFILE_FILE=$(get_shell_profile_file)
 
 	if [ -n "$PROFILE_FILE" ]; then
-		printf "${BLUE}⚙️  Updating shell profile: $PROFILE_FILE${NORMAL}\n"
-
 		# Add new environment variables
 		echo "" >> "$PROFILE_FILE"
 		echo "# Java JRE installed by BoxLang installer" >> "$PROFILE_FILE"
 		echo "export JAVA_HOME=\"$JAVA_INSTALL_DIR\"" >> "$PROFILE_FILE"
 		echo "export PATH=\"\$JAVA_HOME/bin:\$PATH\"" >> "$PROFILE_FILE"
-		printf "${GREEN}✅ Updated shell profile${NORMAL}\n"
-		printf "${YELLOW}⚠️  Please run 'source $PROFILE_FILE' or restart your terminal to use the new Java installation${NORMAL}\n"
+		print_success "Updated shell profile: $PROFILE_FILE"
+		print_warning "Run 'source $PROFILE_FILE' or restart your terminal to use the new Java installation"
 	else
-		printf "${YELLOW}⚠️  Could not determine shell profile file. Please manually add:${NORMAL}\n"
+		print_warning "Could not determine shell profile file. Please manually add:"
 		printf "   export JAVA_HOME=\"$JAVA_INSTALL_DIR\"\n"
 		printf "   export PATH=\"\$JAVA_HOME/bin:\$PATH\"\n"
 	fi
@@ -497,12 +479,8 @@ install_java() {
 	export PATH="$JAVA_HOME/bin:$PATH"
 
 	# Verify installation
-	printf "${BLUE}🔍 Verifying Java installation...${NORMAL}\n"
 	if "$JAVA_BIN/java" -version >/dev/null 2>&1; then
-		local java_version_output=$("$JAVA_BIN/java" -version 2>&1)
-		printf "${GREEN}✅ Java JRE installed successfully!${NORMAL}\n"
-		printf "${BLUE}📋 Version info:${NORMAL}\n"
-		echo "$java_version_output" | head -3
+		print_success "Java JRE installed"
 		return 0
 	else
 		print_error "Java installation verification failed"
@@ -524,7 +502,7 @@ get_shell_profile_file() {
 	local is_wsl=false
 	if [ -f /proc/version ] && grep -q Microsoft /proc/version; then
 		is_wsl=true
-		printf "${BLUE}💡 WSL environment detected${NORMAL}\n"
+		print_info "WSL environment detected" >&2
 	fi
 
 	# Determine the profile file based on shell and system

--- a/src/helpers/helpers.sh
+++ b/src/helpers/helpers.sh
@@ -14,6 +14,12 @@ print_info() {
     printf "%s\n" "$1"
 }
 
+# Only prints when VERBOSE=true - use for routine step-by-step narration
+print_verbose() {
+    [ "${VERBOSE:-false}" = "true" ] && printf "%s\n" "$1"
+    return 0
+}
+
 print_success() {
     printf "${GREEN}✓${NORMAL} %s\n" "$1"
 }
@@ -57,6 +63,13 @@ setup_colors() {
 		WHITE="$(tput setaf 7)"
 		BLACK="$(tput setaf 0)"
 		UNDERLINE="$(tput smul)"
+		DIM="$(tput dim)"
+		# BoxLang brand teal - use a truer teal on 256-color terminals, cyan otherwise
+		if [ "$ncolors" -ge 256 ]; then
+			TEAL="$(tput setaf 37)"
+		else
+			TEAL="$CYAN"
+		fi
 	else
 		RED=""
 		GREEN=""
@@ -69,7 +82,121 @@ setup_colors() {
 		WHITE=""
 		BLACK=""
 		UNDERLINE=""
+		DIM=""
+		TEAL=""
 	fi
+}
+
+###########################################################################
+# BoxLang Logo
+###########################################################################
+BOXLANG_LOGO=' ██████   ██████  ██   ██ ██       █████  ███    ██  ██████
+ ██   ██ ██    ██  ██ ██  ██      ██   ██ ████   ██ ██
+ ██████  ██    ██   ███   ██      ███████ ██ ██  ██ ██   ███
+ ██   ██ ██    ██  ██ ██  ██      ██   ██ ██  ██ ██ ██    ██
+ ██████   ██████  ██   ██ ███████ ██   ██ ██   ████  ██████'
+
+# Prints the teal BoxLang wordmark on real, unicode-capable terminals.
+# Silently does nothing on dumb terminals or piped/redirected output.
+print_logo() {
+	if [ -t 1 ] && [ "${TERM:-}" != "dumb" ] && terminal_supports_unicode; then
+		printf "${TEAL}${BOLD}%s${NORMAL}\n\n" "$BOXLANG_LOGO"
+	fi
+}
+
+###########################################################################
+# Spinner / animated progress bar (non-verbose mode on a real terminal)
+###########################################################################
+terminal_supports_unicode() {
+	local locale="${LC_ALL:-${LC_CTYPE:-${LANG:-}}}"
+	case "$locale" in
+		*UTF-8*|*utf-8*|*UTF8*|*utf8*) return 0 ;;
+	esac
+	case "${TERM_PROGRAM:-}" in
+		Apple_Terminal|iTerm.app|vscode|WezTerm) return 0 ;;
+	esac
+	return 1
+}
+
+spinner_frame() {
+	local step="$1"
+	if terminal_supports_unicode; then
+		case $((step % 10)) in
+			0) printf '⠋' ;; 1) printf '⠙' ;; 2) printf '⠹' ;; 3) printf '⠸' ;; 4) printf '⠼' ;;
+			5) printf '⠴' ;; 6) printf '⠦' ;; 7) printf '⠧' ;; 8) printf '⠇' ;; *) printf '⠏' ;;
+		esac
+	else
+		case $((step % 4)) in
+			0) printf -- '-' ;; 1) printf '\\' ;; 2) printf '|' ;; *) printf '/' ;;
+		esac
+	fi
+}
+
+# run_step "<label>" -- command [args...]
+# On a real, non-verbose terminal: runs the command in the background behind
+# an animated spinner + progress bar, then prints a single "✓ <label>" line.
+# In --verbose mode, or when not attached to a real terminal (piped installs,
+# CI logs): runs the command directly with no animation - the command's own
+# print_verbose() calls (if any) provide the detail instead.
+run_step() {
+	local label="$1"; shift
+	[ "${1:-}" = "--" ] && shift
+
+	if [ "${VERBOSE:-false}" = "true" ] || [ ! -t 1 ] || [ "${TERM:-}" = "dumb" ]; then
+		"$@"
+		local status=$?
+		if [ $status -eq 0 ]; then
+			print_success "$label"
+		fi
+		return $status
+	fi
+
+	_run_step_animated "$label" "$@"
+}
+
+_run_step_animated() {
+	local label="$1"; shift
+	local log_file
+	log_file="$(mktemp)"
+
+	"$@" >"$log_file" 2>&1 &
+	local cmd_pid=$!
+
+	local full empty
+	if terminal_supports_unicode; then full="█"; empty="░"; else full="#"; empty="-"; fi
+
+	printf '\033[?25l'
+	local step=0 width=22 trail=6
+	while kill -0 "$cmd_pid" 2>/dev/null; do
+		local frame
+		frame=$(spinner_frame "$step")
+		local head=$(( step % (width + trail) )) bar="" i=0
+		while [ "$i" -lt "$width" ]; do
+			local age=$(( head - i ))
+			if [ "$age" -ge 0 ] && [ "$age" -lt "$trail" ]; then
+				bar="${bar}${TEAL}${full}${NORMAL}"
+			else
+				bar="${bar}${DIM}${empty}${NORMAL}"
+			fi
+			i=$((i + 1))
+		done
+		printf '\r\033[K  %s %s  %s' "$frame" "$bar" "$label"
+		step=$((step + 1))
+		sleep 0.08
+	done
+
+	local status=0
+	wait "$cmd_pid" || status=$?
+	printf '\r\033[K\033[?25h'
+
+	if [ "$status" -eq 0 ]; then
+		print_success "$label"
+	else
+		print_error "${label} - failed"
+		cat "$log_file" >&2
+	fi
+	rm -f "$log_file"
+	return "$status"
 }
 
 ###########################################################################
@@ -78,7 +205,7 @@ setup_colors() {
 # Verifies required dependencies are installed: curl, unzip and jq
 preflight_check() {
 	local auto_install="${1:-false}"
-	print_info "Checking system requirements..."
+	print_verbose "Checking system requirements..."
 	local missing_deps=()
 
 	# Check required commands dependencies
@@ -174,13 +301,11 @@ preflight_check() {
 		print_error "Java 21 or higher is required to run BoxLang"
 
 		# Otherwise, prompt user for manual installation choice
-		printf "Install it automatically now? (y/N) "
+		printf "☕ Install it automatically now? (y/N) "
 		read -r response
 		case "$response" in
 			[yY][eE][sS]|[yY])
-				print_info "Installing Java..."
 				if install_java; then
-					print_success "Java installed"
 					return 0
 				else
 					print_error "Automatic Java installation failed."
@@ -222,7 +347,7 @@ preflight_check() {
 ###########################################################################
 check_java_version() {
 	local auto_install="${1:-false}"
-	print_info "Checking for Java 21..."
+	print_verbose "Checking for Java 21..."
 	local JAVA_CMD=""
 	local JAVA_VERSION=""
 
@@ -246,7 +371,7 @@ check_java_version() {
 
 	# If running under sudo, try to get the original user's environment
 	if [ -n "${SUDO_USER}" ]; then
-		print_info "Detected sudo execution, checking Java from original user context..."
+		print_verbose "Detected sudo execution, checking Java from original user context..."
 
 		# Try to get Java from the original user's environment
 		local user_java_cmd=$(sudo -u "${SUDO_USER}" -i bash -c 'command -v java 2>/dev/null' || echo "")
@@ -272,7 +397,7 @@ check_java_version() {
 						JAVA_VERSION=$(extract_java_version "$version_output")
 						if [ -n "$JAVA_VERSION" ] && [ "$JAVA_VERSION" -ge 21 ] 2>/dev/null; then
 							JAVA_CMD="$expanded_path"
-							print_success "Found Java ${JAVA_VERSION} at ${JAVA_CMD}"
+							print_verbose "${GREEN}✓${NORMAL} ☕ Found Java ${JAVA_VERSION} at ${JAVA_CMD}"
 							return 0
 						fi
 					fi
@@ -285,7 +410,7 @@ check_java_version() {
 					JAVA_VERSION=$(extract_java_version "$version_output")
 					if [ -n "$JAVA_VERSION" ] && [ "$JAVA_VERSION" -ge 21 ] 2>/dev/null; then
 						JAVA_CMD="$candidate"
-						print_success "Found Java ${JAVA_VERSION} at ${JAVA_CMD}"
+						print_verbose "${GREEN}✓${NORMAL} ☕ Found Java ${JAVA_VERSION} at ${JAVA_CMD}"
 						return 0
 					elif [ -n "$JAVA_VERSION" ]; then
 						print_warning "Found Java ${JAVA_VERSION} at ${candidate}, but Java 21+ is required"
@@ -297,9 +422,8 @@ check_java_version() {
 
 	# If auto_install is true, attempt automatic installation
 	if [ "$auto_install" = "true" ]; then
-		print_info "Java 21+ not found, installing automatically..."
+		print_verbose "Java 21+ not found, installing automatically..."
 		if install_java; then
-			print_success "Java installed"
 			return 0
 		else
 			print_error "Automatic Java installation failed."
@@ -324,7 +448,7 @@ install_java() {
 	local JRE_FILENAME=""
 	local JAVA_INSTALL_DIR=""
 
-	print_info "Installing Java ${JRE_VERSION}..."
+	print_verbose "Installing Java ${JRE_VERSION}..."
 
 	# Normalize architecture names
 	case "$ARCH" in
@@ -361,10 +485,10 @@ install_java() {
 			local LIBC_TYPE="glibc"
 			if [ -f /etc/alpine-release ]; then
 				LIBC_TYPE="musl"
-				print_info "Detected Alpine Linux (musl libc)"
+				print_verbose "Detected Alpine Linux (musl libc)"
 			elif command_exists ldd && ldd --version 2>&1 | grep -q musl; then
 				LIBC_TYPE="musl"
-				print_info "Detected musl libc"
+				print_verbose "Detected musl libc"
 			fi
 
 			# Set JRE URLs based on architecture and libc
@@ -393,15 +517,14 @@ install_java() {
 			;;
 	esac
 
-	print_info "Detected: ${OS} (${ARCH}), installing to ${JAVA_INSTALL_DIR}"
+	print_verbose "Detected: ${OS} (${ARCH}), installing to ${JAVA_INSTALL_DIR}"
 
 	# Create temporary directory
 	local TEMP_DIR=$(mktemp -d)
 	local DOWNLOAD_PATH="$TEMP_DIR/$JRE_FILENAME"
 
 	# Download JRE
-	print_info "Downloading JRE..."
-	if ! curl -L --progress-bar "$JRE_URL" -o "$DOWNLOAD_PATH"; then
+	if ! run_step "☕ Downloaded Java ${JRE_VERSION}" -- curl -fsSL "$JRE_URL" -o "$DOWNLOAD_PATH"; then
 		print_error "Failed to download JRE"
 		rm -rf "$TEMP_DIR"
 		return 1
@@ -423,8 +546,7 @@ install_java() {
 	fi
 
 	# Extract JRE
-	print_info "Extracting JRE..."
-	if ! tar -xzf "$DOWNLOAD_PATH" -C "$TEMP_DIR"; then
+	if ! run_step "Extracted Java runtime" -- tar -xzf "$DOWNLOAD_PATH" -C "$TEMP_DIR"; then
 		print_error "Failed to extract JRE archive"
 		rm -rf "$TEMP_DIR"
 		return 1
@@ -502,7 +624,7 @@ get_shell_profile_file() {
 	local is_wsl=false
 	if [ -f /proc/version ] && grep -q Microsoft /proc/version; then
 		is_wsl=true
-		print_info "WSL environment detected" >&2
+		print_verbose "WSL environment detected" >&2
 	fi
 
 	# Determine the profile file based on shell and system

--- a/src/install-boxlang.sh
+++ b/src/install-boxlang.sh
@@ -26,6 +26,9 @@ TEMP_DIR="${TMPDIR:-/tmp}"
 # empty = prompt, true = install, false = skip
 INSTALL_COMMANDBOX=""
 INSTALL_JRE=""
+# Non-verbose by default: routine step-by-step narration is hidden behind an
+# animated progress indicator. --verbose/-v shows every step as plain text.
+VERBOSE=false
 
 ###########################################################################
 # Get current BoxLang install home
@@ -143,6 +146,7 @@ get_latest_version() {
 # Check for updates and optionally prompt for installation
 ###########################################################################
 check_for_updates() {
+	print_logo
 	print_info "Checking for BoxLang updates..."
 
 	# Get current version
@@ -179,7 +183,7 @@ check_for_updates() {
 			return 0
 			;;
 		2)
-			print_info "A newer version of BoxLang is available."
+			print_info "🔄 A newer version of BoxLang is available."
 			printf "Update to version ${latest_version}? [Y/n] "
 			read -r response < /dev/tty
 			case "$response" in
@@ -241,14 +245,14 @@ check_or_set_path() {
 	# If all entries exist, we're done
 	if [ "$path_exists" = true ] && [ "$install_home_exists" = true ]; then
 		if [ -z "$boxlang_home_bin" ] || [ "$boxlang_home_bin_exists" = true ]; then
-			print_success "PATH entry and BOXLANG_INSTALL_HOME already exist in $profile_file"
+			print_verbose "${GREEN}✓${NORMAL} PATH entry and BOXLANG_INSTALL_HOME already exist in $profile_file"
 			return 0
 		fi
 	fi
 
 	# If PATH exists but BOXLANG_INSTALL_HOME doesn't, add only the install home
 	if [ "$path_exists" = true ] && [ "$install_home_exists" = false ]; then
-		print_info "Adding BOXLANG_INSTALL_HOME to $profile_file (upgrade from older installation)..."
+		print_verbose "Adding BOXLANG_INSTALL_HOME to $profile_file (upgrade from older installation)..."
 		{
 			echo ""
 			echo "# BoxLang installation environment setup - added on $(date)"
@@ -265,11 +269,11 @@ check_or_set_path() {
 
 	# Add PATH to the profile file
 	if [ -n "$boxlang_home_bin" ]; then
-		print_info "Adding [$bin_dir] and [$boxlang_home_bin] to PATH in [$profile_file]..."
+		print_verbose "Adding [$bin_dir] and [$boxlang_home_bin] to PATH in [$profile_file]..."
 	else
-		print_info "Adding [$bin_dir] to PATH in [$profile_file]..."
+		print_verbose "Adding [$bin_dir] to PATH in [$profile_file]..."
 	fi
-	print_info "Adding BOXLANG_INSTALL_HOME [$install_home] in [$profile_file]..."
+	print_verbose "Adding BOXLANG_INSTALL_HOME [$install_home] in [$profile_file]..."
 
 	{
 		echo ""
@@ -310,33 +314,43 @@ check_or_set_path() {
 }
 
 ###########################################################################
+# Downloads, extracts, and links the CommandBox binary (run via run_step)
+###########################################################################
+_install_commandbox_binary() {
+	local system_bin="$1" boxlang_bin="$2" commandbox_url="$3" commandbox_filename="$4" temp_dir="$5"
+	curl -fsSL -o "${temp_dir}/${commandbox_filename}" "${commandbox_url}"
+	unzip -q -o "${temp_dir}/${commandbox_filename}" -d "${temp_dir}/commandbox/"
+	mv "${temp_dir}/commandbox/box" "${boxlang_bin}/box"
+	chmod 755 "${boxlang_bin}/box"
+	ln -sf "${boxlang_bin}/box" "${system_bin}/box"
+	rm -rf "${temp_dir}/${commandbox_filename}" "${temp_dir}/commandbox/"
+}
+
+###########################################################################
 # CommandBox Installation Check and Install Function
 ###########################################################################
 check_and_install_commandbox() {
 	local system_bin="$1"
 	local boxlang_bin="$2"
 
-	print_info "Checking for CommandBox..."
+	print_verbose "Checking for CommandBox..."
 
 	# Check if CommandBox is already available
 	if command_exists box; then
-		print_success "CommandBox is already installed and available"
+		print_verbose "${GREEN}✓${NORMAL} CommandBox is already installed and available"
 		return 0
 	fi
-
-	print_warning "CommandBox is not installed"
-	print_info "CommandBox is the package manager for BoxLang®, used to manage modules, dependencies, and servlet containers."
 
 	# Determine if we should install CommandBox based on flags
 	local should_install=""
 	if [ "$INSTALL_COMMANDBOX" = "true" ]; then
 		should_install="yes"
-		print_info "Installing CommandBox (auto-install enabled)..."
 	elif [ "$INSTALL_COMMANDBOX" = "false" ]; then
 		should_install="no"
-		print_info "Skipping CommandBox installation (--without-commandbox specified)"
+		print_verbose "Skipping CommandBox installation (--without-commandbox specified)"
 	else
 		# Interactive mode - ask user
+		print_info "CommandBox is the package manager for BoxLang®, used to manage modules, dependencies, and servlet containers."
 		printf "Install CommandBox? [Y/n] "
 		read -r response < /dev/tty
 		case "$response" in
@@ -354,40 +368,15 @@ check_and_install_commandbox() {
 		return 0
 	fi
 
-	print_info "Installing CommandBox..."
-
 	# The universal binary for mac/linux is available at the following URL
 	local commandbox_url="https://www.ortussolutions.com/parent/download/commandbox/type/bin"
 	local commandbox_filename="commandbox.zip"
 
-	# Download CommandBox
-	print_info "Downloading CommandBox from ${commandbox_url}..."
-	if ! env curl -L --progress-bar -o "${TEMP_DIR}/${commandbox_filename}" "${commandbox_url}"; then
-		print_error "Failed to download CommandBox"
+	if ! run_step "📦 CommandBox installed" -- _install_commandbox_binary "$system_bin" "$boxlang_bin" "$commandbox_url" "$commandbox_filename" "$TEMP_DIR"; then
+		print_error "Failed to install CommandBox"
 		print_info "Please manually install CommandBox from: https://commandbox.ortusbooks.com/setup/installation"
 		return 1
 	fi
-
-	# Extract CommandBox
-	print_info "Extracting CommandBox..."
-	if ! unzip -o "${TEMP_DIR}/${commandbox_filename}" -d "${TEMP_DIR}/commandbox/"; then
-		print_error "Failed to extract CommandBox"
-		return 1
-	fi
-
-	# Install CommandBox to BoxLang bin directory
-	print_info "Installing CommandBox to ${boxlang_bin}/box..."
-	mv "${TEMP_DIR}/commandbox/box" "${boxlang_bin}/box"
-	chmod 755 "${boxlang_bin}/box"
-
-	# Create symbolic link in system bin directory
-	print_info "Creating CommandBox symbolic link in ${system_bin}..."
-	ln -sf "${boxlang_bin}/box" "${system_bin}/box"
-
-	# Cleanup
-	rm -rf "${TEMP_DIR}/${commandbox_filename}" "${TEMP_DIR}/commandbox/"
-
-	print_success "CommandBox installed successfully"
 	return 0
 }
 
@@ -397,7 +386,7 @@ check_and_install_commandbox() {
 verify_installation() {
 	local bin_dir="$1"
 	local system_bin="$2"
-	print_info "Verifying installation..."
+	print_verbose "Verifying installation..."
 
 	# Make sure BoxLang binary can emit version information
 	if ! "${bin_dir}/boxlang" --version >/dev/null 2>&1; then
@@ -435,11 +424,11 @@ verify_installation() {
 		if [ ! -L "${system_bin}/box" ]; then
 			print_warning "CommandBox symbolic link was not created properly"
 		else
-			print_success "CommandBox is installed and linked"
+			print_verbose "${GREEN}✓${NORMAL} CommandBox is installed and linked"
 		fi
 	fi
 
-	print_success "Installation verified"
+	print_verbose "${GREEN}✓${NORMAL} Installation verified"
 	return 0
 }
 
@@ -447,10 +436,11 @@ verify_installation() {
 # Uninstall BoxLang
 ###########################################################################
 uninstall_boxlang() {
-	print_warning "Uninstalling BoxLang..."
+	print_logo
+	print_warning "🗑️  Uninstalling BoxLang..."
 
 	# Remove symbolic links from system bin directories
-	print_info "Removing system symbolic links..."
+	print_verbose "Removing system symbolic links..."
 	rm -fv /usr/local/bin/boxlang
 	rm -fv /usr/local/bin/bx
 	rm -fv /usr/local/bin/boxlang-miniserver
@@ -460,16 +450,16 @@ uninstall_boxlang() {
 	rm -fv /usr/local/bin/install-bvm
 
 	# Remove BoxLang installation directory
-	print_info "Removing previous BoxLang installation directory..."
+	print_verbose "Removing previous BoxLang installation directory..."
 	rm -rfv /usr/local/boxlang
 
 	# Remove legacy JAR files if they exist
-	print_info "Removing legacy JAR files (if any)..."
+	print_verbose "Removing legacy JAR files (if any)..."
 	rm -fv /usr/local/lib/boxlang-*.jar
 
 	# Also check user-local installation
 	if [ -d "$HOME/.local/bin" ]; then
-		print_info "Checking user-local installation..."
+		print_verbose "Checking user-local installation..."
 		rm -fv "$HOME/.local/bin/boxlang"
 		rm -fv "$HOME/.local/bin/bx"
 		rm -fv "$HOME/.local/bin/boxlang-miniserver"
@@ -481,7 +471,7 @@ uninstall_boxlang() {
 
 	# Remove user-local BoxLang installation directory
 	if [ -d "$HOME/.local/boxlang" ]; then
-		print_info "Removing user-local BoxLang installation directory..."
+		print_verbose "Removing user-local BoxLang installation directory..."
 		rm -rfv "$HOME/.local/boxlang"
 	fi
 
@@ -514,7 +504,8 @@ show_help() {
 	printf "  --without-commandbox   Skip CommandBox installation\n"
 	printf "  --with-jre             Automatically install Java 21 JRE if not found\n"
 	printf "  --without-jre          Skip Java installation (manual installation required)\n"
-	printf "  --yes, -y              Use defaults for all prompts (installs CommandBox and Java)\n\n"
+	printf "  --yes, -y              Use defaults for all prompts (installs CommandBox and Java)\n"
+	printf "  --verbose, -v          Show every step instead of the progress indicator\n\n"
 	printf "${BOLD}Examples:${NORMAL}\n"
 	printf "  install-boxlang\n"
 	printf "  install-boxlang snapshot\n"
@@ -554,6 +545,49 @@ remove_previous_installation() {
 }
 
 ###########################################################################
+# Downloads the BoxLang runtime, MiniServer, and installer bundle (run via run_step)
+###########################################################################
+_download_boxlang_assets() {
+	local temp_dir="$1" download_url="$2" download_url_miniserver="$3" installer_url="$4"
+	rm -f "${temp_dir}/boxlang.zip"
+	curl -fsSL -o "${temp_dir}/boxlang.zip" "${download_url}"
+	rm -f "${temp_dir}/boxlang-miniserver.zip"
+	curl -fsSL -o "${temp_dir}/boxlang-miniserver.zip" "${download_url_miniserver}"
+	rm -f "${temp_dir}/boxlang-installer.zip"
+	curl -fsSL -o "${temp_dir}/boxlang-installer.zip" "${installer_url}"
+}
+
+###########################################################################
+# Unzips assets, sets permissions, and links binaries (run via run_step)
+###########################################################################
+_setup_boxlang_assets() {
+	local system_home="$1" system_bin="$2" destination_bin="$3" destination_scripts="$4" temp_dir="$5"
+	unzip -q -o "${temp_dir}/boxlang.zip" -d "${system_home}"
+	unzip -q -o "${temp_dir}/boxlang-miniserver.zip" -d "${system_home}"
+	unzip -q -o "${temp_dir}/boxlang-installer.zip" -d "${system_home}/scripts"
+	chmod -R 755 "${system_home}"
+
+	# BoxLang binaries with aliases
+	ln -sf "${destination_bin}/boxlang" "${system_bin}/boxlang"
+	ln -sf "${system_bin}/boxlang" "${system_bin}/bx"
+	# MiniServer binaries with aliases
+	ln -sf "${destination_bin}/boxlang-miniserver" "${system_bin}/boxlang-miniserver"
+	ln -sf "${system_bin}/boxlang-miniserver" "${system_bin}/bx-miniserver"
+	# Helper scripts
+	ln -sf "${destination_scripts}/install-boxlang.sh" "${system_bin}/install-boxlang"
+	ln -sf "${destination_scripts}/install-bx-module.sh" "${system_bin}/install-bx-module"
+	ln -sf "${destination_scripts}/install-bx-site.sh" "${system_bin}/install-bx-site"
+	ln -sf "${destination_scripts}/install-bvm.sh" "${system_bin}/install-bvm"
+	ln -sf "${destination_scripts}/bvm.sh" "${system_bin}/bvm"
+
+	# Cleanup
+	rm -f "${temp_dir}"/boxlang*.zip
+	# Remove Windows-specific files that may have been downloaded
+	rm -f "${destination_bin}"/*.bat "${destination_bin}"/*.ps1
+	rm -f "${destination_scripts}"/*.bat "${destination_scripts}"/*.ps1
+}
+
+###########################################################################
 # Handle the main installation
 ###########################################################################
 install_boxlang() {
@@ -579,6 +613,8 @@ install_boxlang() {
 		FORCE_INSTALL=true
 	fi
 
+	print_logo
+
 	###########################################################################
 	# Pre-flight Checks
 	# This function checks for necessary tools and environment
@@ -601,14 +637,14 @@ install_boxlang() {
 	###########################################################################
 
 	if [ "$FORCE_INSTALL" = false ]; then
-		print_info "Checking for existing BoxLang installation..."
+		print_verbose "Checking for existing BoxLang installation..."
 		local CURRENT_VERSION=$(get_current_version)
 		if [ $? -eq 0 ] && [ -n "$CURRENT_VERSION" ]; then
 			print_warning "BoxLang is already installed at [${SYSTEM_HOME}] with version [${CURRENT_VERSION}]"
 			printf "Use 'install-boxlang --uninstall' to remove it, '--force' to reinstall, or '--help' for more options.\n"
 			exit 0;
 		else
-			print_success "No previous BoxLang installation found, proceeding with fresh install..."
+			print_verbose "${GREEN}✓${NORMAL} No previous BoxLang installation found, proceeding with fresh install..."
 		fi
 	else
 		print_warning "Forcing reinstallation of BoxLang..."
@@ -665,69 +701,22 @@ install_boxlang() {
 	# Start the installation
 	###########################################################################
 	print_info "Installing BoxLang® [${TARGET_VERSION}] to [${SYSTEM_HOME}]"
-	print_info "Downloading, please wait..."
 
-	###########################################################################
-	# Download BoxLang
-	###########################################################################
-	rm -f "${TEMP_DIR}"/boxlang.zip
-	env curl -L --progress-bar -o "${TEMP_DIR}"/boxlang.zip "${DOWNLOAD_URL}" || {
-		print_error "Download of BoxLang® binary failed"
+	# Download the runtime, MiniServer, and installer bundle
+	if ! run_step "Downloaded BoxLang®" -- _download_boxlang_assets "$TEMP_DIR" "$DOWNLOAD_URL" "$DOWNLOAD_URL_MINISERVER" "$INSTALLER_URL"; then
+		print_error "Download of BoxLang® failed"
 		exit 1
-	}
-	# Download BoxLang MiniServer
-	rm -f "${TEMP_DIR}"/boxlang-miniserver.zip
-	env curl -L --progress-bar -o "${TEMP_DIR}"/boxlang-miniserver.zip "${DOWNLOAD_URL_MINISERVER}" || {
-		print_error "Download of BoxLang® MiniServer binary failed"
+	fi
+
+	# Unzip, set permissions, and link binaries
+	if ! run_step "BoxLang® is set up" -- _setup_boxlang_assets "$SYSTEM_HOME" "$SYSTEM_BIN" "$DESTINATION_BIN" "$DESTINATION_SCRIPTS" "$TEMP_DIR"; then
+		print_error "Setting up BoxLang® failed"
 		exit 1
-	}
-	# Download BoxLang Installer Bundle
-	rm -f "${TEMP_DIR}"/boxlang-installer.zip
-	env curl -L --progress-bar -o "${TEMP_DIR}"/boxlang-installer.zip "${INSTALLER_URL}" || {
-		print_error "Download of BoxLang® Installer bundle failed"
-		exit 1
-	}
-
-	###########################################################################
-	# Inflate them
-	###########################################################################
-	print_info "Unzipping assets to ${SYSTEM_HOME}..."
-	unzip -q -o "${TEMP_DIR}"/boxlang.zip -d "${SYSTEM_HOME}"
-	unzip -q -o "${TEMP_DIR}"/boxlang-miniserver.zip -d "${SYSTEM_HOME}"
-	unzip -q -o "${TEMP_DIR}"/boxlang-installer.zip -d "${SYSTEM_HOME}/scripts"
-
-	###########################################################################
-	# Make them executable
-	###########################################################################
-	chmod -R 755 "${SYSTEM_HOME}"
-
-	###########################################################################
-	# Add internal links within BoxLang home
-	###########################################################################
-	print_info "Adding system symbolic links..."
-	# BoxLang Binaries with aliases
-	ln -sf "${DESTINATION_BIN}/boxlang" "${SYSTEM_BIN}/boxlang"
-	ln -sf "${SYSTEM_BIN}/boxlang" "${SYSTEM_BIN}/bx"
-	# MiniServer Binaries with aliases
-	ln -sf "${DESTINATION_BIN}/boxlang-miniserver" "${SYSTEM_BIN}/boxlang-miniserver"
-	ln -sf "${SYSTEM_BIN}/boxlang-miniserver" "${SYSTEM_BIN}/bx-miniserver"
-	# Helper scripts
-	ln -sf "${DESTINATION_SCRIPTS}/install-boxlang.sh" "${SYSTEM_BIN}/install-boxlang"
-	ln -sf "${DESTINATION_SCRIPTS}/install-bx-module.sh" "${SYSTEM_BIN}/install-bx-module"
-	ln -sf "${DESTINATION_SCRIPTS}/install-bx-site.sh" "${SYSTEM_BIN}/install-bx-site"
-	ln -sf "${DESTINATION_SCRIPTS}/install-bvm.sh" "${SYSTEM_BIN}/install-bvm"
-	ln -sf "${DESTINATION_SCRIPTS}/bvm.sh" "${SYSTEM_BIN}/bvm"
+	fi
 
 	# CommandBox Installation
 	# In the future this will be part of BoxLang
 	check_and_install_commandbox "$SYSTEM_BIN" "$DESTINATION_BIN"
-
-	# Cleanup
-	print_info "Cleaning up..."
-	rm -f "${TEMP_DIR}"/boxlang*.zip
-	# Remove Windows-specific files that may have been downloaded
-	rm -f "${DESTINATION_BIN}"/*.bat "${DESTINATION_BIN}"/*.ps1
-	rm -f "${DESTINATION_SCRIPTS}"/*.bat "${DESTINATION_SCRIPTS}"/*.ps1
 
 	# Verify installation
 	verify_installation "$DESTINATION_BIN" "$SYSTEM_BIN"
@@ -740,7 +729,7 @@ install_boxlang() {
 	check_or_set_path "$SYSTEM_BIN" "$SYSTEM_HOME" "$BOXLANG_HOME_BIN"
 
 	printf "\n"
-	print_success "BoxLang® was installed successfully."
+	print_success "🎉 BoxLang® was installed successfully."
 	printf "\n"
 	printf "Installed to:  ${BOLD}${SYSTEM_HOME}${NORMAL}\n"
 	printf "System links:  ${BOLD}${SYSTEM_BIN}${NORMAL}\n"
@@ -778,7 +767,7 @@ main() {
 				command="check-update"
 				break
 				;;
-			"--version"|"-v")
+			"--version")
 				command="version"
 				break
 				;;
@@ -793,6 +782,9 @@ main() {
 				;;
 			"--without-jre")
 				INSTALL_JRE=false
+				;;
+			"--verbose"|"-v")
+				VERBOSE=true
 				;;
 			"--yes"|"-y")
 				# Setup all defaults here.

--- a/src/install-boxlang.sh
+++ b/src/install-boxlang.sh
@@ -488,7 +488,7 @@ uninstall_boxlang() {
 # Help Function
 ###########################################################################
 show_help() {
-	printf "${BOLD}BoxLang® Quick Installer${NORMAL} v${INSTALLER_VERSION}\n"
+	printf "${BOLD}📦 BoxLang® Quick Installer${NORMAL} v${INSTALLER_VERSION}\n"
 	printf "Installs the BoxLang® runtime, MiniServer, and tools.\n\n"
 	printf "${BOLD}Usage:${NORMAL}\n"
 	printf "  install-boxlang [version] [options]\n\n"

--- a/src/install-boxlang.sh
+++ b/src/install-boxlang.sh
@@ -234,7 +234,7 @@ check_or_set_path() {
 	fi
 
 	# Check if BOXLANG_INSTALL_HOME is already set in the profile
-	if [ -f "$profile_file" ] && grep -Fq "BOXLANG_INSTALL_HOME" "$profile_file" ]; then
+	if [ -f "$profile_file" ] && grep -Fq "BOXLANG_INSTALL_HOME" "$profile_file"; then
 		install_home_exists=true
 	fi
 

--- a/src/install-boxlang.sh
+++ b/src/install-boxlang.sh
@@ -66,16 +66,15 @@ elif [ -f "${BASH_SOURCE%/*}/helpers/helpers.sh" ]; then
 	source "${BASH_SOURCE%/*}/helpers/helpers.sh"
 else
 	# Download helpers.sh if it doesn't exist locally
-	printf "${BLUE}⬇️ Downloading helper functions...${NORMAL}\n"
+	printf "Downloading helper functions...\n"
 	helpers_url="https://downloads.ortussolutions.com/ortussolutions/boxlang-quick-installer/helpers/helpers.sh"
 	helpers_file="${TEMP_DIR}/helpers.sh"
 
 	if curl -fsSL "$helpers_url" -o "$helpers_file"; then
 		chmod +x "$helpers_file"
 		source "$helpers_file"
-		print_success "Helper functions downloaded successfully"
 	else
-		printf "${RED}🔴 Error: Failed to download helper functions from [$helpers_url] to [${TEMP_DIR}]${NORMAL}\n"
+		printf "${RED}Error: Failed to download helper functions from [$helpers_url] to [${TEMP_DIR}]${NORMAL}\n" >&2
 		exit 1
 	fi
 fi
@@ -144,32 +143,31 @@ get_latest_version() {
 # Check for updates and optionally prompt for installation
 ###########################################################################
 check_for_updates() {
-	print_info "🔍 Checking for BoxLang updates..."
+	print_info "Checking for BoxLang updates..."
 
 	# Get current version
 	local current_version
-	current_version=$(get_current_version)
-	if [ $? -ne 0 ] || [ -z "$current_version" ]; then
-		print_warning "⚠️  BoxLang is not currently installed"
+	current_version=$(get_current_version) || true
+	if [ -z "$current_version" ]; then
+		print_warning "BoxLang is not currently installed"
 		current_version="0.0.0"
 	fi
 
 	# Get latest version
 	local latest_version
-	latest_version=$(get_latest_version)
-	if [ $? -ne 0 ] || [ -z "$latest_version" ]; then
+	latest_version=$(get_latest_version) || true
+	if [ -z "$latest_version" ]; then
 		print_error "Failed to fetch latest version information"
 		print_warning "Please check your internet connection and try again"
 		return 1
 	fi
 
-	printf "${GREEN}Current version: ${current_version}${NORMAL}\n"
-	printf "${GREEN}Latest version:  ${latest_version}${NORMAL}\n"
-	printf "\n"
+	printf "Current version: ${BOLD}${current_version}${NORMAL}\n"
+	printf "Latest version:  ${BOLD}${latest_version}${NORMAL}\n\n"
 
 	# Compare versions
-	compare_versions "$current_version" "$latest_version"
-	local comparison_result=$?
+	local comparison_result=0
+	compare_versions "$current_version" "$latest_version" || comparison_result=$?
 
 	case $comparison_result in
 		0)
@@ -177,21 +175,20 @@ check_for_updates() {
 			return 0
 			;;
 		1)
-			print_info "🔄 You have a newer version than the latest release"
-			print_warning "This might be a development or snapshot build"
+			print_info "You have a newer version than the latest release (development or snapshot build)"
 			return 0
 			;;
 		2)
-			print_warning "🆙 A newer version of BoxLang is available!"
-			print_info "Would you like to update to version ${latest_version}? [Y/n]"
+			print_info "A newer version of BoxLang is available."
+			printf "Update to version ${latest_version}? [Y/n] "
 			read -r response < /dev/tty
 			case "$response" in
 				[nN][oO]|[nN])
-					print_warning "Update cancelled"
+					print_info "Update cancelled"
 					return 0
 					;;
 				*)
-					print_info "Starting update to BoxLang ${latest_version}..."
+					print_info "Updating to BoxLang ${latest_version}..."
 					# Call main installation function with latest version
 					exec "$0" "latest"
 					;;
@@ -251,7 +248,7 @@ check_or_set_path() {
 
 	# If PATH exists but BOXLANG_INSTALL_HOME doesn't, add only the install home
 	if [ "$path_exists" = true ] && [ "$install_home_exists" = false ]; then
-		print_info "➕ Adding BOXLANG_INSTALL_HOME to $profile_file (upgrade from older installation)..."
+		print_info "Adding BOXLANG_INSTALL_HOME to $profile_file (upgrade from older installation)..."
 		{
 			echo ""
 			echo "# BoxLang installation environment setup - added on $(date)"
@@ -268,11 +265,11 @@ check_or_set_path() {
 
 	# Add PATH to the profile file
 	if [ -n "$boxlang_home_bin" ]; then
-		print_info "➕ Adding [$bin_dir] and [$boxlang_home_bin] to PATH in [$profile_file]..."
+		print_info "Adding [$bin_dir] and [$boxlang_home_bin] to PATH in [$profile_file]..."
 	else
-		print_info "➕ Adding [$bin_dir] to PATH in [$profile_file]..."
+		print_info "Adding [$bin_dir] to PATH in [$profile_file]..."
 	fi
-	print_info "➕ Adding BOXLANG_INSTALL_HOME [$install_home] in [$profile_file]..."
+	print_info "Adding BOXLANG_INSTALL_HOME [$install_home] in [$profile_file]..."
 
 	{
 		echo ""
@@ -296,30 +293,12 @@ check_or_set_path() {
 	} >> "$profile_file"
 
 	if [ -n "$boxlang_home_bin" ]; then
-		print_success "Successfully added [$bin_dir] and [$boxlang_home_bin] to PATH in [$profile_file]"
+		print_success "Added [$bin_dir] and [$boxlang_home_bin] to PATH in [$profile_file]"
 	else
-		print_success "Successfully added [$bin_dir] to PATH in [$profile_file]"
-	fi
-	printf "${RED}─────────────────────────────────────────────────────────────────────────────${NORMAL}\n"
-
-	# Special handling for WSL
-	if [ "$is_wsl" = true ]; then
-		print_warning "IMPORTANT: You may need to restart your terminal or run:"
-		if [ "$current_shell" = "fish" ]; then
-			printf "${CYAN}source $profile_file${NORMAL}\n"
-		else
-			printf "${CYAN}source $profile_file${NORMAL}\n"
-		fi
-	else
-		print_warning "IMPORTANT: Restart your terminal or run the following to use the new PATH:"
-		if [ "$current_shell" = "fish" ]; then
-			printf "${CYAN}source $profile_file${NORMAL}\n"
-		else
-			printf "${CYAN}source $profile_file${NORMAL}\n"
-		fi
+		print_success "Added [$bin_dir] to PATH in [$profile_file]"
 	fi
 
-	printf "${RED}─────────────────────────────────────────────────────────────────────────────${NORMAL}\n"
+	print_warning "Restart your terminal or run: source $profile_file"
 
 	# Update current session PATH
 	if [ -n "$boxlang_home_bin" ]; then
@@ -337,7 +316,7 @@ check_and_install_commandbox() {
 	local system_bin="$1"
 	local boxlang_bin="$2"
 
-	print_info "🔍 Checking for CommandBox..."
+	print_info "Checking for CommandBox..."
 
 	# Check if CommandBox is already available
 	if command_exists box; then
@@ -346,20 +325,19 @@ check_and_install_commandbox() {
 	fi
 
 	print_warning "CommandBox is not installed"
-	print_info "💡 CommandBox is the Package Manager for BoxLang®"
-	print_info "💡 It allows you to easily manage BoxLang modules, dependencies, start servlet containers, and more${NORMAL}"
+	print_info "CommandBox is the package manager for BoxLang®, used to manage modules, dependencies, and servlet containers."
 
 	# Determine if we should install CommandBox based on flags
 	local should_install=""
 	if [ "$INSTALL_COMMANDBOX" = "true" ]; then
 		should_install="yes"
-		print_info "📦 Installing CommandBox (auto-install enabled)..."
+		print_info "Installing CommandBox (auto-install enabled)..."
 	elif [ "$INSTALL_COMMANDBOX" = "false" ]; then
 		should_install="no"
-		print_info "⏭️  Skipping CommandBox installation (--without-commandbox specified)"
+		print_info "Skipping CommandBox installation (--without-commandbox specified)"
 	else
 		# Interactive mode - ask user
-		print_info "❓ Would you like to install CommandBox? [Y/n]"
+		printf "Install CommandBox? [Y/n] "
 		read -r response < /dev/tty
 		case "$response" in
 			[nN][oO]|[nN])
@@ -372,11 +350,11 @@ check_and_install_commandbox() {
 	fi
 
 	if [ "$should_install" != "yes" ]; then
-		print_info "💡 You can install CommandBox later from: https://commandbox.ortusbooks.com/setup/installation"
+		print_info "You can install CommandBox later from: https://commandbox.ortusbooks.com/setup/installation"
 		return 0
 	fi
 
-	print_info "📦 Installing CommandBox..."
+	print_info "Installing CommandBox..."
 
 	# The universal binary for mac/linux is available at the following URL
 	local commandbox_url="https://www.ortussolutions.com/parent/download/commandbox/type/bin"
@@ -386,7 +364,7 @@ check_and_install_commandbox() {
 	print_info "Downloading CommandBox from ${commandbox_url}..."
 	if ! env curl -L --progress-bar -o "${TEMP_DIR}/${commandbox_filename}" "${commandbox_url}"; then
 		print_error "Failed to download CommandBox"
-		print_info "💡 Please manually install CommandBox from: https://commandbox.ortusbooks.com/setup/installation"
+		print_info "Please manually install CommandBox from: https://commandbox.ortusbooks.com/setup/installation"
 		return 1
 	fi
 
@@ -419,7 +397,7 @@ check_and_install_commandbox() {
 verify_installation() {
 	local bin_dir="$1"
 	local system_bin="$2"
-	print_info "🔍 Verifying installation..."
+	print_info "Verifying installation..."
 
 	# Make sure BoxLang binary can emit version information
 	if ! "${bin_dir}/boxlang" --version >/dev/null 2>&1; then
@@ -457,11 +435,11 @@ verify_installation() {
 		if [ ! -L "${system_bin}/box" ]; then
 			print_warning "CommandBox symbolic link was not created properly"
 		else
-			print_success "👊 CommandBox is installed and linked"
+			print_success "CommandBox is installed and linked"
 		fi
 	fi
 
-	print_success "👊 Installation verified successfully"
+	print_success "Installation verified"
 	return 0
 }
 
@@ -469,10 +447,10 @@ verify_installation() {
 # Uninstall BoxLang
 ###########################################################################
 uninstall_boxlang() {
-	print_warning "🗑️  Uninstalling BoxLang..."
+	print_warning "Uninstalling BoxLang..."
 
 	# Remove symbolic links from system bin directories
-	print_info "🔗 Removing system symbolic links..."
+	print_info "Removing system symbolic links..."
 	rm -fv /usr/local/bin/boxlang
 	rm -fv /usr/local/bin/bx
 	rm -fv /usr/local/bin/boxlang-miniserver
@@ -482,16 +460,16 @@ uninstall_boxlang() {
 	rm -fv /usr/local/bin/install-bvm
 
 	# Remove BoxLang installation directory
-	print_info "📁 Removing previous BoxLang installation directory..."
+	print_info "Removing previous BoxLang installation directory..."
 	rm -rfv /usr/local/boxlang
 
 	# Remove legacy JAR files if they exist
-	print_info "🫙 Removing legacy JAR files (if any)..."
+	print_info "Removing legacy JAR files (if any)..."
 	rm -fv /usr/local/lib/boxlang-*.jar
 
 	# Also check user-local installation
 	if [ -d "$HOME/.local/bin" ]; then
-		print_info "👤 Checking user-local installation..."
+		print_info "Checking user-local installation..."
 		rm -fv "$HOME/.local/bin/boxlang"
 		rm -fv "$HOME/.local/bin/bx"
 		rm -fv "$HOME/.local/bin/boxlang-miniserver"
@@ -503,7 +481,7 @@ uninstall_boxlang() {
 
 	# Remove user-local BoxLang installation directory
 	if [ -d "$HOME/.local/boxlang" ]; then
-		print_info "📁 Removing user-local BoxLang installation directory..."
+		print_info "Removing user-local BoxLang installation directory..."
 		rm -rfv "$HOME/.local/boxlang"
 	fi
 
@@ -512,58 +490,42 @@ uninstall_boxlang() {
 		rm -fv "$HOME/.local/lib/boxlang-*.jar"
 	fi
 
-	print_success "✅ BoxLang uninstalled successfully"
-	print_info "💡 BoxLang Home directory (~/.boxlang) was preserved"
-	print_info "💡 To remove it completely, run: rm -rf ~/.boxlang"
+	print_success "BoxLang uninstalled successfully"
+	print_info "BoxLang Home directory (~/.boxlang) was preserved. To remove it completely, run: rm -rf ~/.boxlang"
 }
 
 ###########################################################################
 # Help Function
 ###########################################################################
 show_help() {
-	printf "${GREEN}📦 BoxLang® Quick Installer v${INSTALLER_VERSION}${NORMAL}\n\n"
-	printf "${YELLOW}This script installs the BoxLang® runtime, MiniServer and tools on your system.${NORMAL}\n\n"
-	printf "${BOLD}USAGE:${NORMAL}\n"
-	printf "  install-boxlang [version] [options]\n"
-	printf "  install-boxlang --help\n\n"
-	printf "${BOLD}ARGUMENTS:${NORMAL}\n"
-	printf "  [version]         (Optional) Specify which version to install\n"
-	printf "                    - ${BOLD}'latest' (default)${NORMAL}: Install the latest stable release\n"
-	printf "                    - ${BOLD}'snapshot'${NORMAL}: Install the latest development snapshot\n"
-	printf "                    - ${BOLD}'1.2.0'${NORMAL}: Install a specific version number\n\n"
-	printf "${BOLD}OPTIONS:${NORMAL}\n"
-	printf "  --help, -h        	Show this help message\n"
-	printf "  --uninstall       	Remove BoxLang from the system\n"
-	printf "  --check-update    	Check if a newer version is available\n"
-	printf "  --system          	Force system-wide installation (requires sudo)\n"
-	printf "  --force           	Force reinstallation even if already installed\n"
-	printf "  --with-commandbox 	Install CommandBox without prompting\n"
-	printf "  --without-commandbox 	Skip CommandBox installation\n"
-	printf "  --with-jre        	Automatically install Java 21 JRE if not found\n"
-	printf "  --without-jre     	Skip Java installation (manual installation required)\n"
-	printf "  --yes, -y         	Use defaults for all prompts (installs CommandBox and Java)\n\n"
-	printf "${BOLD}EXAMPLES:${NORMAL}\n"
+	printf "${BOLD}BoxLang® Quick Installer${NORMAL} v${INSTALLER_VERSION}\n"
+	printf "Installs the BoxLang® runtime, MiniServer, and tools.\n\n"
+	printf "${BOLD}Usage:${NORMAL}\n"
+	printf "  install-boxlang [version] [options]\n\n"
+	printf "${BOLD}Arguments:${NORMAL}\n"
+	printf "  [version]              'latest' (default), 'snapshot', or a specific version like '1.2.0'\n\n"
+	printf "${BOLD}Options:${NORMAL}\n"
+	printf "  --help, -h             Show this help message\n"
+	printf "  --uninstall            Remove BoxLang from the system\n"
+	printf "  --check-update         Check if a newer version is available\n"
+	printf "  --system               Force system-wide installation (requires sudo)\n"
+	printf "  --force                Force reinstallation even if already installed\n"
+	printf "  --with-commandbox      Install CommandBox without prompting\n"
+	printf "  --without-commandbox   Skip CommandBox installation\n"
+	printf "  --with-jre             Automatically install Java 21 JRE if not found\n"
+	printf "  --without-jre          Skip Java installation (manual installation required)\n"
+	printf "  --yes, -y              Use defaults for all prompts (installs CommandBox and Java)\n\n"
+	printf "${BOLD}Examples:${NORMAL}\n"
 	printf "  install-boxlang\n"
-	printf "  install-boxlang latest\n"
 	printf "  install-boxlang snapshot\n"
-	printf "  install-boxlang 1.2.0\n"
-	printf "  install-boxlang --force\n"
-	printf "  install-boxlang --with-commandbox\n"
-	printf "  install-boxlang --without-commandbox\n"
-	printf "  install-boxlang --with-jre\n"
-	printf "  install-boxlang --without-jre\n"
-	printf "  install-boxlang --with-commandbox --with-jre\n"
+	printf "  install-boxlang 1.2.0 --force\n"
 	printf "  install-boxlang --yes\n"
 	printf "  install-boxlang --uninstall\n"
 	printf "  install-boxlang --check-update\n"
 	printf "  sudo install-boxlang --system\n\n"
-	printf "${BOLD}NON-INTERACTIVE USAGE:${NORMAL}\n"
-	printf "  🌐 Install with CommandBox: ${GREEN}curl -fsSL https://boxlang.io/install.sh | bash -s -- --with-commandbox${NORMAL}\n"
-	printf "  🌐 Install without CommandBox: ${GREEN}curl -fsSL https://boxlang.io/install.sh | bash -s -- --without-commandbox${NORMAL}\n"
-	printf "  🌐 Install with Java auto-install: ${GREEN}curl -fsSL https://boxlang.io/install.sh | bash -s -- --with-jre${NORMAL}\n"
-	printf "  🌐 Full auto-install (Java + CommandBox): ${GREEN}curl -fsSL https://boxlang.io/install.sh | bash -s -- --yes${NORMAL}\n"
-	printf "  🌐 Install with defaults: ${GREEN}curl -fsSL https://boxlang.io/install.sh | bash -s -- --yes${NORMAL}\n\n"
-	# ... rest of help text remains the same
+	printf "${BOLD}Non-interactive:${NORMAL}\n"
+	printf "  curl -fsSL https://boxlang.io/install.sh | bash -s -- --yes\n"
+	printf "  curl -fsSL https://boxlang.io/install.sh | bash -s -- --with-jre --with-commandbox\n"
 }
 
 ###########################################################################
@@ -572,7 +534,7 @@ show_help() {
 remove_previous_installation() {
 	# Remove previous BoxLang installation if it exists
 	if [ -d "${SYSTEM_HOME}" ]; then
-		print_warning "🗑️ Removing previous BoxLang installation..."
+		print_warning "Removing previous BoxLang installation..."
 		rm -rf "${SYSTEM_HOME}"
 
 		# Remove old symbolic links from system bin
@@ -586,7 +548,7 @@ remove_previous_installation() {
 	fi
 	# Remove $HOME/.boxlang/classes directory to make sure no old classes remain
 	if [ -d "$HOME/.boxlang/classes" ]; then
-		print_warning "🗑️ Removing old BoxLang classes from home directory..."
+		print_warning "Removing old BoxLang classes from home directory..."
 		rm -rf "$HOME/.boxlang/classes"
 	fi
 }
@@ -639,21 +601,19 @@ install_boxlang() {
 	###########################################################################
 
 	if [ "$FORCE_INSTALL" = false ]; then
-		print_info "🔍 Checking for existing BoxLang installation..."
+		print_info "Checking for existing BoxLang installation..."
 		local CURRENT_VERSION=$(get_current_version)
 		if [ $? -eq 0 ] && [ -n "$CURRENT_VERSION" ]; then
-			print_warning "⚠️  BoxLang is already installed at [${SYSTEM_HOME}] with version[${CURRENT_VERSION}]"
-			print_info "💡 Use ${GREEN}'install-boxlang.sh --uninstall'${BLUE} to remove the existing version before reinstalling."
-			print_info "💡 Or use ${GREEN}'--force'${BLUE} to do a forced reinstall."
-			print_info "💡 Or use ${GREEN}'--help'${BLUE} for more information."
+			print_warning "BoxLang is already installed at [${SYSTEM_HOME}] with version [${CURRENT_VERSION}]"
+			printf "Use 'install-boxlang --uninstall' to remove it, '--force' to reinstall, or '--help' for more options.\n"
 			exit 0;
 		else
 			print_success "No previous BoxLang installation found, proceeding with fresh install..."
 		fi
 	else
-		print_warning "🔄 Forcing reinstallation of BoxLang..."
+		print_warning "Forcing reinstallation of BoxLang..."
 		remove_previous_installation || {
-			print_error "❌ Failed to remove previous installation, please see log for more information"
+			print_error "Failed to remove previous installation, please see log for more information"
 			exit 1
 		}
 	fi
@@ -662,11 +622,7 @@ install_boxlang() {
 	# Support user-local installation if not running as root and not explicitly system install
 	###########################################################################
 	if [ "$EUID" -ne 0 ] && [[ ! " ${new_args[@]} " =~ " --system " ]]; then
-		printf "${BLUE}─────────────────────────────────────────────────────────────────────────────${NORMAL}\n"
-		print_warning "🥸 Installing to user directory (~/.local) since not running as root"
-		print_info "💡 Use ${GREEN}'sudo install-boxlang.sh'${BLUE} for system-wide installation"
-		printf "${BLUE}─────────────────────────────────────────────────────────────────────────────${NORMAL}\n"
-		printf "\n"
+		print_warning "Installing to user directory (~/.local) since not running as root. Use 'sudo install-boxlang' for system-wide installation."
 		SYSTEM_HOME="$HOME/.local/boxlang"
 		SYSTEM_BIN="$HOME/.local/bin"
 	fi
@@ -708,36 +664,34 @@ install_boxlang() {
 	###########################################################################
 	# Start the installation
 	###########################################################################
-	print_info "🎯 Installing BoxLang® ${GREEN}[${TARGET_VERSION}]${BLUE} to ${GREEN}[${SYSTEM_HOME}]"
-	print_warning "⌛ Downloading Please wait..."
-	print_info "${DOWNLOAD_URL}"
+	print_info "Installing BoxLang® [${TARGET_VERSION}] to [${SYSTEM_HOME}]"
+	print_info "Downloading, please wait..."
 
 	###########################################################################
 	# Download BoxLang
 	###########################################################################
 	rm -f "${TEMP_DIR}"/boxlang.zip
 	env curl -L --progress-bar -o "${TEMP_DIR}"/boxlang.zip "${DOWNLOAD_URL}" || {
-		print_error "Error: Download of BoxLang® binary failed"
+		print_error "Download of BoxLang® binary failed"
 		exit 1
 	}
 	# Download BoxLang MiniServer
 	rm -f "${TEMP_DIR}"/boxlang-miniserver.zip
 	env curl -L --progress-bar -o "${TEMP_DIR}"/boxlang-miniserver.zip "${DOWNLOAD_URL_MINISERVER}" || {
-		print_error "Error: Download of BoxLang® MiniServer binary failed"
+		print_error "Download of BoxLang® MiniServer binary failed"
 		exit 1
 	}
 	# Download BoxLang Installer Bundle
 	rm -f "${TEMP_DIR}"/boxlang-installer.zip
 	env curl -L --progress-bar -o "${TEMP_DIR}"/boxlang-installer.zip "${INSTALLER_URL}" || {
-		print_error "Error: Download of BoxLang® Installer bundle failed"
+		print_error "Download of BoxLang® Installer bundle failed"
 		exit 1
 	}
 
 	###########################################################################
 	# Inflate them
 	###########################################################################
-	printf "\n"
-	print_info "🛺 Unzipping Assets to ${SYSTEM_HOME}..."
+	print_info "Unzipping assets to ${SYSTEM_HOME}..."
 	unzip -q -o "${TEMP_DIR}"/boxlang.zip -d "${SYSTEM_HOME}"
 	unzip -q -o "${TEMP_DIR}"/boxlang-miniserver.zip -d "${SYSTEM_HOME}"
 	unzip -q -o "${TEMP_DIR}"/boxlang-installer.zip -d "${SYSTEM_HOME}/scripts"
@@ -745,13 +699,12 @@ install_boxlang() {
 	###########################################################################
 	# Make them executable
 	###########################################################################
-	print_info "⚡Making Assets Executable..."
 	chmod -R 755 "${SYSTEM_HOME}"
 
 	###########################################################################
 	# Add internal links within BoxLang home
 	###########################################################################
-	print_info "🔗 Adding system symbolic links..."
+	print_info "Adding system symbolic links..."
 	# BoxLang Binaries with aliases
 	ln -sf "${DESTINATION_BIN}/boxlang" "${SYSTEM_BIN}/boxlang"
 	ln -sf "${SYSTEM_BIN}/boxlang" "${SYSTEM_BIN}/bx"
@@ -770,8 +723,7 @@ install_boxlang() {
 	check_and_install_commandbox "$SYSTEM_BIN" "$DESTINATION_BIN"
 
 	# Cleanup
-	printf "\n"
-	print_info "🗑️  Cleaning up..."
+	print_info "Cleaning up..."
 	rm -f "${TEMP_DIR}"/boxlang*.zip
 	# Remove Windows-specific files that may have been downloaded
 	rm -f "${DESTINATION_BIN}"/*.bat "${DESTINATION_BIN}"/*.ps1
@@ -782,31 +734,23 @@ install_boxlang() {
 
 	# Create bin directory in BoxLang home for module executables
 	local BOXLANG_HOME_BIN="$HOME/.boxlang/bin"
-	print_info "📁 Creating BoxLang home bin directory..."
 	mkdir -p "$BOXLANG_HOME_BIN"
-	print_success "BoxLang home bin directory created at [$BOXLANG_HOME_BIN]"
 
 	# Check PATH for local user execution mostly.
 	check_or_set_path "$SYSTEM_BIN" "$SYSTEM_HOME" "$BOXLANG_HOME_BIN"
 
-	printf "${GREEN}"
-	printf "─────────────────────────────────────────────────────────────────────────────\n"
-	echo "🥊 BoxLang® Installation Directory: [${SYSTEM_HOME}]"
-	echo "🔗 System Links: [${SYSTEM_BIN}]"
-	echo "🏠 BoxLang® Home is now set to your user home [~/.boxlang] by default"
-	echo "${MAGENTA}✅ Remember you can check for updates at any time with: ${GREEN}install-boxlang --check-update${NORMAL}"
-	printf "${GREEN}"
-	printf "─────────────────────────────────────────────────────────────────────────────\n"
-	echo 'BoxLang® - Dynamic : Modular : Productive : https://boxlang.io'
-	printf "─────────────────────────────────────────────────────────────────────────────\n"
-	echo "BoxLang® is FREE and Open-Source Software under the Apache 2.0 License"
-	echo "You can also buy support and enhanced versions at https://boxlang.io/plans"
-	echo 'p.s. Follow us at https://x.com/tryboxlang.'
-	echo 'p.p.s. Clone us and star us at https://github.com/ortus-boxlang/boxlang'
-	echo 'Please support us via Patreon at https://www.patreon.com/ortussolutions'
-	printf "─────────────────────────────────────────────────────────────────────────────\n"
-	echo "Copyright and Registered Trademarks of Ortus Solutions, Corp"
-	printf "${NORMAL}"
+	printf "\n"
+	print_success "BoxLang® was installed successfully."
+	printf "\n"
+	printf "Installed to:  ${BOLD}${SYSTEM_HOME}${NORMAL}\n"
+	printf "System links:  ${BOLD}${SYSTEM_BIN}${NORMAL}\n"
+	printf "BoxLang Home:  ${BOLD}~/.boxlang${NORMAL}\n"
+	printf "\n"
+	printf "Run it with: ${BOLD}boxlang${NORMAL} (or ${BOLD}bx${NORMAL})\n"
+	printf "Check for updates any time with: ${BOLD}install-boxlang --check-update${NORMAL}\n"
+	printf "\n"
+	printf "BoxLang® is free and open-source under the Apache 2.0 License.\n"
+	printf "Docs: https://boxlang.io  •  Support: https://boxlang.io/plans  •  GitHub: https://github.com/ortus-boxlang/boxlang\n"
 }
 
 ###########################################################################
@@ -882,8 +826,7 @@ main() {
 			install_boxlang "${args[@]}"
 			;;
 		"version")
-			# Print the installer version
-			printf "${GREEN}🥊 BoxLang Installer Version v%s\n" "$INSTALLER_VERSION${NORMAL}"
+			printf "BoxLang Installer v%s\n" "$INSTALLER_VERSION"
 			;;
 		*)
 			print_error "Unknown command: $command"

--- a/src/install-bvm.sh
+++ b/src/install-bvm.sh
@@ -35,15 +35,14 @@ elif [ -f "${BVM_HOME}/scripts/helpers.sh" ]; then
 	source "${BVM_HOME}/scripts/helpers.sh"
 else
 	# Download helpers.sh if it doesn't exist locally
-	printf "${BLUE}⬇️ Downloading helper functions...${NORMAL}\n"
-	printf "${BLUE}─────────────────────────────────────────────────────────────────────────────${NORMAL}\n"
+	printf "Downloading helper functions...\n"
 	helpers_url="https://downloads.ortussolutions.com/ortussolutions/boxlang-quick-installer/helpers/helpers.sh"
 	helpers_file="${TEMP_DIR}/helpers.sh"
 
 	if curl -fsSL "$helpers_url" -o "$helpers_file"; then
 		source "$helpers_file"
 	else
-		printf "${RED}Error: Failed to download helper functions from $helpers_url${NORMAL}\n"
+		printf "${RED}Error: Failed to download helper functions from $helpers_url${NORMAL}\n" >&2
 		exit 1
 	fi
 fi
@@ -136,7 +135,8 @@ setup_path() {
     print_info "Setting up PATH for BVM..."
 
     # Use helper function to detect shell profile file
-    local profile_file=$(get_shell_profile_file)
+    # Intentionally not `local` - show_help() reads this after we return
+    profile_file=$(get_shell_profile_file)
 
     # Check if BVM is already in PATH
     if echo "$PATH" | grep -q "$bvm_bin"; then
@@ -224,7 +224,7 @@ show_help() {
 main() {
 	setup_colors
 
-    print_header "📦 BVM (BoxLang Version Manager) Installer"
+    print_header "BVM (BoxLang Version Manager) Installer"
     printf "\n"
 
 	# Pre-flight Checks
@@ -242,9 +242,9 @@ main() {
         exit 1
     fi
 
-	printf "${BLUE}─────────────────────────────────────────────────────────────────────────────${NORMAL}\n"
-    print_success "❤️‍🔥 BVM has been installed successfully"
-    printf "${BLUE}─────────────────────────────────────────────────────────────────────────────${NORMAL}\n"
+    printf "\n"
+    print_success "BVM was installed successfully."
+    printf "\n"
 
     # Show instructions
     show_help

--- a/src/install-bvm.sh
+++ b/src/install-bvm.sh
@@ -25,6 +25,9 @@ TEMP_DIR="${TMPDIR:-/tmp}"
 BVM_HOME="${BVM_HOME:-$HOME/.bvm}"
 BVM_SOURCE_URL="https://downloads.ortussolutions.com/ortussolutions/boxlang-quick-installer/bvm.sh"
 INSTALLER_URL="https://downloads.ortussolutions.com/ortussolutions/boxlang-quick-installer/boxlang-installer.zip"
+# Non-verbose by default: routine step-by-step narration is hidden behind an
+# animated progress indicator. --verbose/-v shows every step as plain text.
+VERBOSE=false
 
 # Helpers
 if [ -f "$(dirname "$0")/helpers/helpers.sh" ]; then
@@ -48,81 +51,69 @@ else
 fi
 
 ###########################################################################
-# Install BVM
+# Downloads the installer bundle and lays out BVM's directory structure
+# (run via run_step)
 ###########################################################################
-install_bvm() {
-    # Create BVM directory
-    print_info "Creating BVM directory at [$BVM_HOME]"
-    mkdir -p "$BVM_HOME/bin" "$BVM_HOME/versions" "$BVM_HOME/cache" "$BVM_HOME/scripts"
-    local bvm_script="$BVM_HOME/bin/bvm"
-	local scripts_dir="$BVM_HOME/scripts"
+_install_bvm_bundle() {
+	local bvm_home="$1" temp_dir="$2" installer_url="$3"
+	local scripts_dir="$bvm_home/scripts"
 
-	###########################################################################
-	# Download BoxLang Installer Scripts
-	###########################################################################
-    print_info "Downloading BVM from [${INSTALLER_URL}]"
-	env curl -L --progress-bar -o "${TEMP_DIR}"/boxlang-installer.zip "${INSTALLER_URL}" || {
-		print_error "Error: Download of BoxLang® Installer bundle failed"
-		exit 1
-	}
+	print_verbose "Creating BVM directory at [$bvm_home]"
+	mkdir -p "$bvm_home/bin" "$bvm_home/versions" "$bvm_home/cache" "$scripts_dir"
 
-	###########################################################################
-	# Inflate them
-	###########################################################################
-	print_info "Inflating BoxLang installer scripts..."
-	unzip -q -o "${TEMP_DIR}"/boxlang-installer.zip -d "${scripts_dir}"
+	print_verbose "Downloading BVM from [${installer_url}]"
+	curl -fsSL -o "${temp_dir}/boxlang-installer.zip" "${installer_url}"
 
-	###########################################################################
-	# Make them executable
-	###########################################################################
-	print_info "Making BoxLang installer scripts executable..."
+	print_verbose "Inflating BoxLang installer scripts..."
+	unzip -q -o "${temp_dir}/boxlang-installer.zip" -d "${scripts_dir}"
 	chmod -R 755 "${scripts_dir}"
 
-	###########################################################################
-	# Add internal links within BoxLang home
-	###########################################################################
-
-	print_info "Creating internal links for BoxLang scripts..."
+	print_verbose "Creating internal links for BoxLang scripts..."
 	# Create symlinks for install-bx-module, install-bx-site, bvm
-	ln -sf "$scripts_dir/install-bx-module.sh" "$BVM_HOME/bin/install-bx-module"
-	ln -sf "$scripts_dir/install-bx-site.sh" "$BVM_HOME/bin/install-bx-site"
-	ln -sf "$scripts_dir/install-bvm.sh" "$BVM_HOME/bin/install-bvm"
-	ln -sf "$scripts_dir/bvm.sh" "$BVM_HOME/bin/bvm"
+	ln -sf "$scripts_dir/install-bx-module.sh" "$bvm_home/bin/install-bx-module"
+	ln -sf "$scripts_dir/install-bx-site.sh" "$bvm_home/bin/install-bx-site"
+	ln -sf "$scripts_dir/install-bvm.sh" "$bvm_home/bin/install-bvm"
+	ln -sf "$scripts_dir/bvm.sh" "$bvm_home/bin/bvm"
 
-    # Create convenience wrapper scripts for direct access to BoxLang tools
-    print_info "Creating convenience wrapper scripts..."
+	print_verbose "Creating convenience wrapper scripts..."
 
-    # Create boxlang wrapper
-    cat > "$BVM_HOME/bin/boxlang" << 'EOF'
+	# Create boxlang wrapper
+	cat > "$bvm_home/bin/boxlang" << 'EOF'
 #!/bin/bash
 # BoxLang wrapper script for BVM
 exec "$(dirname "$0")/bvm" exec "$@"
 EOF
 
-    # Create bx wrapper
-    cat > "$BVM_HOME/bin/bx" << 'EOF'
+	# Create bx wrapper
+	cat > "$bvm_home/bin/bx" << 'EOF'
 #!/bin/bash
 # BoxLang (bx) wrapper script for BVM
 exec "$(dirname "$0")/bvm" exec "$@"
 EOF
 
-    # Create boxlang-miniserver wrapper
-    cat > "$BVM_HOME/bin/boxlang-miniserver" << 'EOF'
+	# Create boxlang-miniserver wrapper
+	cat > "$bvm_home/bin/boxlang-miniserver" << 'EOF'
 #!/bin/bash
 # BoxLang MiniServer wrapper script for BVM
 exec "$(dirname "$0")/bvm" miniserver "$@"
 EOF
 
-    # Create bx-miniserver wrapper
-    cat > "$BVM_HOME/bin/bx-miniserver" << 'EOF'
+	# Create bx-miniserver wrapper
+	cat > "$bvm_home/bin/bx-miniserver" << 'EOF'
 #!/bin/bash
 # BoxLang MiniServer (bx-miniserver) wrapper script for BVM
 exec "$(dirname "$0")/bvm" miniserver "$@"
 EOF
 
-    # Make all wrapper scripts executable
-    chmod -R 755 "$BVM_HOME/bin"/*
-    print_success "BVM script and wrappers installed to [$BVM_HOME]"
+	# Make all wrapper scripts executable
+	chmod -R 755 "$bvm_home/bin"/*
+}
+
+###########################################################################
+# Install BVM
+###########################################################################
+install_bvm() {
+	run_step "BVM installed to [$BVM_HOME]" -- _install_bvm_bundle "$BVM_HOME" "$TEMP_DIR" "$INSTALLER_URL"
 }
 
 ###########################################################################
@@ -132,7 +123,7 @@ setup_path() {
     local bvm_bin="$BVM_HOME/bin"
     local shell_name="${SHELL##*/}"
 
-    print_info "Setting up PATH for BVM..."
+    print_verbose "Setting up PATH for BVM..."
 
     # Use helper function to detect shell profile file
     # Intentionally not `local` - show_help() reads this after we return
@@ -140,17 +131,17 @@ setup_path() {
 
     # Check if BVM is already in PATH
     if echo "$PATH" | grep -q "$bvm_bin"; then
-        print_success "BVM is already in PATH"
+        print_verbose "${GREEN}✓${NORMAL} BVM is already in PATH"
         return 0
     fi
 
     # Check if BVM path is already in profile
     if grep -q "$bvm_bin" "$profile_file" 2>/dev/null; then
-        print_success "BVM path already configured in $profile_file"
+        print_verbose "${GREEN}✓${NORMAL} BVM path already configured in $profile_file"
         return 0
     fi
 
-    print_info "Adding BVM to PATH in $profile_file"
+    print_verbose "Adding BVM to PATH in $profile_file"
 
     # Add BVM to PATH
     {
@@ -224,30 +215,40 @@ show_help() {
 main() {
 	setup_colors
 
-    print_header "BVM (BoxLang Version Manager) Installer"
-    printf "\n"
+	# Parse arguments
+	for arg in "$@"; do
+		case "$arg" in
+			"--verbose"|"-v")
+				VERBOSE=true
+				;;
+		esac
+	done
+
+	print_logo
+	print_header "BVM (BoxLang Version Manager) Installer"
+	printf "\n"
 
 	# Pre-flight Checks
 	if ! preflight_check; then
 		exit 1
 	fi
 
-    # Install BVM
-    if ! install_bvm; then
-        exit 1
-    fi
+	# Install BVM
+	if ! install_bvm; then
+		exit 1
+	fi
 
-    # Setup PATH
-    if ! setup_path; then
-        exit 1
-    fi
+	# Setup PATH
+	if ! setup_path; then
+		exit 1
+	fi
 
-    printf "\n"
-    print_success "BVM was installed successfully."
-    printf "\n"
+	printf "\n"
+	print_success "🎉 BVM was installed successfully."
+	printf "\n"
 
-    # Show instructions
-    show_help
+	# Show instructions
+	show_help
 }
 
 # Run main function

--- a/tests/specs/helpers_test.sh
+++ b/tests/specs/helpers_test.sh
@@ -102,19 +102,19 @@ test_print_functions() {
 
     # Test print_info
     local info_output=$(print_info "test message" 2>&1)
-    assert_contains "ℹ️ test message" "$info_output" "print_info() outputs correct format"
+    assert_contains "test message" "$info_output" "print_info() outputs correct format"
 
     # Test print_success
     local success_output=$(print_success "test success" 2>&1)
-    assert_contains "✅ test success" "$success_output" "print_success() outputs correct format"
+    assert_contains "✓ test success" "$success_output" "print_success() outputs correct format"
 
     # Test print_warning
     local warning_output=$(print_warning "test warning" 2>&1)
-    assert_contains "⚠️  test warning" "$warning_output" "print_warning() outputs correct format"
+    assert_contains "test warning" "$warning_output" "print_warning() outputs correct format"
 
     # Test print_error
     local error_output=$(print_error "test error" 2>&1)
-    assert_contains "🔴 test error" "$error_output" "print_error() outputs correct format"
+    assert_contains "✗ test error" "$error_output" "print_error() outputs correct format"
 
     # Test print_header
     local header_output=$(print_header "Test Header" 2>&1)


### PR DESCRIPTION
Strip emoji and decorative dividers from print_info/success/warning/error
and every status line in install-boxlang.sh and install-bvm.sh, replacing
them with a terser, near-zero-emoji style (checkmark on success, x on
error only) modeled after pi.dev's installer.

Along the way, fixed three latent set -e bugs uncovered while testing the
reworked messaging: --check-update exited silently instead of prompting
for an update, get_shell_profile_file()'s WSL notice could corrupt its own
return value when captured via command substitution, and BVM's post-install
instructions referenced an out-of-scope $profile_file that was always blank.