### PR TITLE
Install module dependencies declared in box.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,9 @@ install-bx-module --update --force --local
 # Install a project's dependencies (reads ./box.json, like `npm install`)
 install-bx-module
 
+# Same, but into the local boxlang_modules folder instead of BoxLang HOME
+install-bx-module --local
+
 # Get help
 install-bx-module --help
 ```
@@ -345,7 +348,7 @@ Module installations are tracked in a `box.json` dependencies manifest. Global m
 
 If an installed module's own `box.json` declares a `dependencies` entry, those dependencies are installed automatically right after it: a `"*"` (or empty/null) version installs the latest ForgeBox version, while any other value — an exact version, `be`, or `snapshot` — is installed as specified. Circular dependency chains are detected and skipped.
 
-Running `install-bx-module` with no arguments checks the current directory for its own `box.json`. If one is found, its declared `dependencies` are installed the same way, so a project's dependencies can be installed with a single command, similar to running `npm install` with no arguments. If no `box.json` is present, the usual usage help is shown instead.
+Running `install-bx-module` with no module names checks the current directory for its own `box.json`. If one is found, its declared `dependencies` are installed the same way, so a project's dependencies can be installed with a single command, similar to running `npm install` with no arguments. This works both with no arguments at all (installs to BoxLang HOME) and with `--local` alone (installs into `./boxlang_modules`). If no `box.json` is present, the usual usage help is shown instead.
 
 ## 🌐 Running Applications
 

--- a/README.md
+++ b/README.md
@@ -334,11 +334,18 @@ install-bx-module --update --force
 install-bx-module --outdated --local
 install-bx-module --update --force --local
 
+# Install a project's dependencies (reads ./box.json, like `npm install`)
+install-bx-module
+
 # Get help
 install-bx-module --help
 ```
 
 Module installations are tracked in a `box.json` dependencies manifest. Global modules use `~/.boxlang/modules/box.json`, while `--local` modules use `./boxlang_modules/box.json`. Installing and removing modules updates the manifest, and `--list` can generate a missing manifest from modules that were installed previously.
+
+If an installed module's own `box.json` declares a `dependencies` entry, those dependencies are installed automatically right after it: a `"*"` (or empty/null) version installs the latest ForgeBox version, while any other value — an exact version, `be`, or `snapshot` — is installed as specified. Circular dependency chains are detected and skipped.
+
+Running `install-bx-module` with no arguments checks the current directory for its own `box.json`. If one is found, its declared `dependencies` are installed the same way, so a project's dependencies can be installed with a single command, similar to running `npm install` with no arguments. If no `box.json` is present, the usual usage help is shown instead.
 
 ## 🌐 Running Applications
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `--non-interactive` to the BoxLang installers. It skips prompts using their existing defaults and is enabled automatically when standard input is redirected.
 - `install-bx-module` now installs module dependencies automatically. When an installed module's own `box.json` declares a `dependencies` entry, each one is installed too: a `"*"` (or empty/null) version resolves to the latest ForgeBox version, while any other value — an exact version, `be`, or `snapshot` — is installed as specified. Circular dependency chains are detected and skipped.
-- Running `install-bx-module` with no arguments now checks the current directory for a `box.json`. If one exists, its declared `dependencies` are installed (to BoxLang HOME, same as a normal install), the same way `npm install` installs a project's dependencies with no arguments. Without a `box.json` present, the usual usage error is shown.
+- Running `install-bx-module` with no module names now checks the current directory for a `box.json`. If one exists, its declared `dependencies` are installed, the same way `npm install` installs a project's dependencies with no arguments. This works both with no arguments at all (installs to BoxLang HOME) and with `--local` alone (installs into `./boxlang_modules`). Without a `box.json` present, the usual usage error is shown.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `--non-interactive` to the BoxLang installers. It skips prompts using their existing defaults and is enabled automatically when standard input is redirected.
+- `install-bx-module` now installs module dependencies automatically. When an installed module's own `box.json` declares a `dependencies` entry, each one is installed too: a `"*"` (or empty/null) version resolves to the latest ForgeBox version, while any other value — an exact version, `be`, or `snapshot` — is installed as specified. Circular dependency chains are detected and skipped.
+- Running `install-bx-module` with no arguments now checks the current directory for a `box.json`. If one exists, its declared `dependencies` are installed (to BoxLang HOME, same as a normal install), the same way `npm install` installs a project's dependencies with no arguments. Without a `box.json` present, the usual usage error is shown.
 
 ### Fixed
 
 - Fixed the Windows installer to honor `BOXLANG_INSTALL_HOME` for custom installation paths, while retaining `C:\boxlang` as the default.
+- Fixed `install-bx-module.sh` parsing tab-delimited `jq` output with `IFS=$'\t'`, which POSIX `/bin/sh` (dash, BusyBox ash) does not expand, so fields were never actually being split.
 
 ## [1.32.0] - 2026-07-31
 

--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -244,6 +244,7 @@ function Show-Help {
     Write-Host "  - Use --local to work with modules in current directory's boxlang_modules folder"
     Write-Host "  - Without --local, modules are managed in BoxLang HOME (~/.boxlang/modules)"
     Write-Host "  - Requires PowerShell to be installed"
+    Write-Host "  - Dependencies declared in a module's box.json are installed automatically (latest version for `"*`", otherwise the version specified)"
 }
 
 function Set-BoxJsonDependency {
@@ -592,8 +593,43 @@ function Get-LatestVersionFromForgebox {
     }
 }
 
+function Install-ModuleDependencies {
+    param(
+        [PSCustomObject]$BoxJson,
+        [string[]]$Visited
+    )
+
+    if (-not $BoxJson -or -not $BoxJson.dependencies) { return }
+
+    $depNames = $BoxJson.dependencies.PSObject.Properties.Name
+    if (-not $depNames -or $depNames.Count -eq 0) { return }
+
+    $depNoun = if ($depNames.Count -eq 1) { "dependency" } else { "dependencies" }
+    Write-Host "🔗 Found $($depNames.Count) module $depNoun, installing..." -ForegroundColor Blue
+
+    foreach ($depName in $depNames) {
+        if ($Visited -contains $depName) {
+            Write-Host "⚠️  Skipping circular dependency: $depName" -ForegroundColor Yellow
+            continue
+        }
+
+        $depVersion = $BoxJson.dependencies.$depName
+        $depInput = if (-not $depVersion -or $depVersion -eq "*" -or $depVersion -eq "null") {
+            $depName
+        } else {
+            "$depName@$depVersion"
+        }
+
+        Write-Host "📦 Installing dependency: $depInput" -ForegroundColor Green
+        Install-Module -moduleName $depInput -Visited $Visited
+    }
+}
+
 function Install-Module {
-    param([string]$moduleName)
+    param(
+        [string]$moduleName,
+        [string[]]$Visited = @()
+    )
 
     $targetModule = ""
     $targetVersion = ""
@@ -769,6 +805,9 @@ boxlang module:$moduleName %*
                         }
                     }
                 }
+
+                # Install any module dependencies declared in box.json
+                Install-ModuleDependencies -BoxJson $boxJson -Visited ($Visited + $targetModule)
             } catch {
                 # Silently ignore box.json parsing errors
             }

--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -206,6 +206,7 @@ function Show-Help {
     Write-Host "  install-bx-module.ps1 --list [--local]"
     Write-Host "  install-bx-module.ps1 --outdated [--local]"
     Write-Host "  install-bx-module.ps1 --update [--force] [--local]"
+    Write-Host "  install-bx-module.ps1 (no arguments, run from a directory with a box.json)"
     Write-Host "  install-bx-module.ps1 --help"
     Write-Host ""
     Write-Host "Arguments:" -ForegroundColor DarkYellow
@@ -236,6 +237,7 @@ function Show-Help {
     Write-Host "  install-bx-module.ps1 --outdated --local"
     Write-Host "  install-bx-module.ps1 --update"
     Write-Host "  install-bx-module.ps1 --update --force --local"
+    Write-Host "  install-bx-module.ps1"
     Write-Host ""
     Write-Host "Notes:" -ForegroundColor DarkYellow
     Write-Host "  - If no version is specified, the latest version from FORGEBOX will be installed"
@@ -245,6 +247,7 @@ function Show-Help {
     Write-Host "  - Without --local, modules are managed in BoxLang HOME (~/.boxlang/modules)"
     Write-Host "  - Requires PowerShell to be installed"
     Write-Host "  - Dependencies declared in a module's box.json are installed automatically (latest version for `"*`", otherwise the version specified, including `"be`" or `"snapshot`")"
+    Write-Host "  - Running with no arguments installs the dependencies declared in a box.json in the current directory, if one exists"
 }
 
 function Set-BoxJsonDependency {
@@ -896,8 +899,29 @@ function Remove-Module {
 
 # Main execution starts here
 
-# Check if no arguments are passed
+# Check if no arguments are passed. If a box.json exists in the current
+# directory, treat it as a project manifest and install the dependencies it
+# declares (similar to running `npm install` with no arguments).
 if ($args.Count -eq 0) {
+    $projectBoxJsonPath = Join-Path (Get-Location) "box.json"
+    if (Test-Path $projectBoxJsonPath) {
+        if (-not $env:BOXLANG_HOME) {
+            $env:BOXLANG_HOME = Join-Path $env:USERPROFILE ".boxlang"
+        }
+        $MODULES_HOME = Join-Path $env:BOXLANG_HOME "modules"
+        $LOCAL_INSTALL = $false
+
+        Write-Host "📄 Found box.json in $(Get-Location), installing its declared dependencies..." -ForegroundColor Yellow
+        try {
+            $projectBoxJson = Get-Content $projectBoxJsonPath -Raw | ConvertFrom-Json
+            Install-ModuleDependencies -BoxJson $projectBoxJson -Visited @()
+        } catch {
+            Write-Host "❌ Error: Failed to parse box.json: $($_.Exception.Message)" -ForegroundColor Red
+            exit 1
+        }
+        exit 0
+    }
+
     Write-Host "❌ Error: No module(s) specified" -ForegroundColor Red
     Write-Host "💡 This script installs or removes BoxLang modules." -ForegroundColor Yellow
 	Show-Help

--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -244,7 +244,7 @@ function Show-Help {
     Write-Host "  - Use --local to work with modules in current directory's boxlang_modules folder"
     Write-Host "  - Without --local, modules are managed in BoxLang HOME (~/.boxlang/modules)"
     Write-Host "  - Requires PowerShell to be installed"
-    Write-Host "  - Dependencies declared in a module's box.json are installed automatically (latest version for `"*`", otherwise the version specified)"
+    Write-Host "  - Dependencies declared in a module's box.json are installed automatically (latest version for `"*`", otherwise the version specified, including `"be`" or `"snapshot`")"
 }
 
 function Set-BoxJsonDependency {

--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -899,35 +899,6 @@ function Remove-Module {
 
 # Main execution starts here
 
-# Check if no arguments are passed. If a box.json exists in the current
-# directory, treat it as a project manifest and install the dependencies it
-# declares (similar to running `npm install` with no arguments).
-if ($args.Count -eq 0) {
-    $projectBoxJsonPath = Join-Path (Get-Location) "box.json"
-    if (Test-Path $projectBoxJsonPath) {
-        if (-not $env:BOXLANG_HOME) {
-            $env:BOXLANG_HOME = Join-Path $env:USERPROFILE ".boxlang"
-        }
-        $MODULES_HOME = Join-Path $env:BOXLANG_HOME "modules"
-        $LOCAL_INSTALL = $false
-
-        Write-Host "📄 Found box.json in $(Get-Location), installing its declared dependencies..." -ForegroundColor Yellow
-        try {
-            $projectBoxJson = Get-Content $projectBoxJsonPath -Raw | ConvertFrom-Json
-            Install-ModuleDependencies -BoxJson $projectBoxJson -Visited @()
-        } catch {
-            Write-Host "❌ Error: Failed to parse box.json: $($_.Exception.Message)" -ForegroundColor Red
-            exit 1
-        }
-        exit 0
-    }
-
-    Write-Host "❌ Error: No module(s) specified" -ForegroundColor Red
-    Write-Host "💡 This script installs or removes BoxLang modules." -ForegroundColor Yellow
-	Show-Help
-    exit 1
-}
-
 # Show help if requested
 if ($args[0] -eq "--help" -or $args[0] -eq "-h") {
     Show-Help
@@ -1104,13 +1075,38 @@ if ($REMOVE_MODE) {
     exit 0
 }
 
+# No module names were given (either no arguments at all, or only --local).
+# If a box.json exists in the current directory, treat it as a project
+# manifest and install the dependencies it declares (similar to running
+# `npm install` with no arguments), honoring --local/BoxLang HOME just like a
+# normal install would.
+$modules = Parse-ModuleList $currentArgs
+if ($modules.Count -eq 0) {
+    $projectBoxJsonPath = Join-Path (Get-Location) "box.json"
+    if (Test-Path $projectBoxJsonPath) {
+        Write-Host "📄 Found box.json in $(Get-Location), installing its declared dependencies..." -ForegroundColor Yellow
+        try {
+            $projectBoxJson = Get-Content $projectBoxJsonPath -Raw | ConvertFrom-Json
+            Install-ModuleDependencies -BoxJson $projectBoxJson -Visited @()
+        } catch {
+            Write-Host "❌ Error: Failed to parse box.json: $($_.Exception.Message)" -ForegroundColor Red
+            exit 1
+        }
+        exit 0
+    }
+
+    Write-Host "❌ Error: No module(s) specified" -ForegroundColor Red
+    Write-Host "💡 This script installs or removes BoxLang modules." -ForegroundColor Yellow
+    Show-Help
+    exit 1
+}
+
 # Inform about local installation
 if ($LOCAL_INSTALL) {
     Write-Host "📍 Installing modules locally in $(Get-Location)\boxlang_modules" -ForegroundColor Yellow
 }
 
-# Parse comma/space-delimited module list and install
-$modules = Parse-ModuleList $currentArgs
+# Install the parsed comma/space-delimited module list
 foreach ($module in $modules) {
     if ($module) {
         Write-Host "🚀 Starting installation of module: $module" -ForegroundColor Green

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -18,6 +18,10 @@ set -e
 # Configuration
 FORGEBOX_API_URL="https://forgebox.io/api/v1"
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+# A literal tab character for use as an IFS field separator when parsing
+# tab-delimited jq output. `$'\t'` is a bash/ksh-ism that POSIX /bin/sh
+# (dash, BusyBox ash) does not expand, so it must be built with printf instead.
+TAB="$(printf '\t')"
 
 # We need this in case the target OS we are installing in does not have a `TERM` implementation declared
 # or when TERM is set to problematic values like "unknown" (common in CI environments like GitHub Actions or Docker containers)
@@ -108,6 +112,7 @@ show_help() {
 	printf "  - Use --local to work with modules in current directory's boxlang_modules folder\n"
 	printf "  - Without --local, modules are managed in BoxLang HOME (~/.boxlang/modules)\n"
 	printf "  - Requires curl and jq to be installed\n"
+	printf "  - Dependencies declared in a module's box.json are installed automatically (latest version for \"*\", otherwise the version specified)\n"
 }
 
 list_modules() {
@@ -138,7 +143,7 @@ list_modules() {
 		printf "${YELLOW}📭 No modules installed${NORMAL}\n"
 	else
 		jq -r '.dependencies // {} | to_entries[] | "\(.key)\t\(.value)"' "${BOX_JSON_PATH}" 2>/dev/null |
-		while IFS=$'\t' read -r module_name module_version; do
+		while IFS="$TAB" read -r module_name module_version; do
 			printf -- "✓ %s (%s)\n" "$module_name" "$module_version"
 		done
 	fi
@@ -312,6 +317,10 @@ get_snapshot_version_from_forgebox() {
 
 install_module() {
 	local INPUT=${1}
+	# Space-delimited list of modules already being installed up the dependency
+	# chain (including the module currently being processed). Used to guard
+	# against circular dependencies when recursively installing box.json deps.
+	local VISITED=${2:-""}
 	local TARGET_MODULE=""
 	local TARGET_VERSION=""
 
@@ -476,11 +485,63 @@ EOF
 			fi
 		fi
 	fi
+
+	# Install any module dependencies declared in the extracted module's box.json
+	install_module_dependencies "${DESTINATION}" "${VISITED} ${TARGET_MODULE}"
+
 	# Track this install in the modules manifest
 	box_json_set_dependency "${MODULES_HOME}/box.json" "${TARGET_MODULE}" "${TARGET_VERSION}"
 
 	# Success message
 	printf "${GREEN}✅ BoxLang® Module [${TARGET_MODULE}@${TARGET_VERSION}] installed!${NORMAL}\n"
+}
+
+# Reads a module's own box.json (as extracted to MODULE_DIR) and installs any
+# declared dependencies. A dependency version of "*" (or empty/null) installs
+# the latest version from FORGEBOX; any other value is installed as-is
+# (e.g. an exact version, "be", or "snapshot").
+install_module_dependencies() {
+	local MODULE_DIR=${1}
+	local VISITED=${2:-""}
+	local BOX_JSON_PATH="${MODULE_DIR}/box.json"
+
+	[ -f "${BOX_JSON_PATH}" ] || return 0
+
+	# `|| true` keeps a jq failure (e.g. malformed box.json) from tripping `set -e`.
+	local DEP_COUNT
+	DEP_COUNT=$(jq -r '.dependencies // {} | length' "${BOX_JSON_PATH}" 2>/dev/null || true)
+
+	# Guard against a non-numeric DEP_COUNT (see list_modules() for why).
+	if [ -z "$DEP_COUNT" ] || [ "${DEP_COUNT:-0}" -eq 0 ] 2>/dev/null; then
+		return 0
+	fi
+
+	printf "${BLUE}🔗 Found %s module dependenc%s, installing...${NORMAL}\n" \
+		"$DEP_COUNT" "$([ "$DEP_COUNT" -eq 1 ] && echo "y" || echo "ies")"
+
+	jq -r '.dependencies // {} | to_entries[] | "\(.key)\t\(.value)"' "${BOX_JSON_PATH}" 2>/dev/null |
+	while IFS="$TAB" read -r dep_name dep_version; do
+		[ -z "$dep_name" ] && continue
+
+		# Skip dependencies already being installed up the chain to avoid
+		# infinite recursion on circular module dependencies.
+		case " ${VISITED} " in
+			*" ${dep_name} "*)
+				printf "${YELLOW}⚠️  Skipping circular dependency: ${dep_name}${NORMAL}\n"
+				continue
+				;;
+		esac
+
+		local dep_input
+		if [ -z "$dep_version" ] || [ "$dep_version" = "null" ] || [ "$dep_version" = "*" ]; then
+			dep_input="${dep_name}"
+		else
+			dep_input="${dep_name}@${dep_version}"
+		fi
+
+		printf "${GREEN}📦 Installing dependency: ${dep_input}${NORMAL}\n"
+		install_module "$dep_input" "${VISITED}"
+	done
 }
 
 remove_module() {
@@ -649,7 +710,7 @@ compute_outdated_report() {
 	BOX_JSON_PATH=$(ensure_modules_manifest "${MODULES_PATH}")
 
 	jq -r '.dependencies // {} | to_entries[] | "\(.key)\t\(.value)"' "${BOX_JSON_PATH}" 2>/dev/null |
-	while IFS=$'\t' read -r module_name current_version; do
+	while IFS="$TAB" read -r module_name current_version; do
 		local current_semver
 		current_semver=$(extract_semantic_version "$current_version")
 		[ -z "$current_semver" ] && continue
@@ -710,7 +771,7 @@ outdated_modules() {
 
 	local OUTDATED_MODULES=""
 	local OUTDATED_COUNT=0
-	while IFS=$'\t' read -r module_name current_version latest_version status; do
+	while IFS="$TAB" read -r module_name current_version latest_version status; do
 		local status_label
 		case "$status" in
 			uptodate) status_label="✅ up to date" ;;
@@ -771,7 +832,7 @@ update_modules() {
 
 	local OUTDATED_MODULES=""
 	local OUTDATED_COUNT=0
-	while IFS=$'\t' read -r module_name current_version latest_version status; do
+	while IFS="$TAB" read -r module_name current_version latest_version status; do
 		if [ "$status" = "outdated" ]; then
 			printf -- "🆙 %s: %s → %s\n" "$module_name" "$current_version" "$latest_version"
 			OUTDATED_MODULES="${OUTDATED_MODULES}${module_name}|${latest_version}

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -78,6 +78,7 @@ show_help() {
 	printf "  install-bx-module.sh --list [--local]\n"
 	printf "  install-bx-module.sh --outdated [--local]\n"
 	printf "  install-bx-module.sh --update [--force] [--local]\n"
+	printf "  install-bx-module.sh (no arguments, run from a directory with a box.json)\n"
 	printf "  install-bx-module.sh --help\n\n"
 	printf "${BOLD}ARGUMENTS:${NORMAL}\n"
 	printf "  <module-name>     The name(s) of the module(s) to install. (Comma or space delimmited)\n"
@@ -104,7 +105,8 @@ show_help() {
 	printf "  install-bx-module --outdated\n"
 	printf "  install-bx-module --outdated --local\n"
 	printf "  install-bx-module --update\n"
-	printf "  install-bx-module --update --force --local\n\n"
+	printf "  install-bx-module --update --force --local\n"
+	printf "  install-bx-module\n\n"
 	printf "${BOLD}NOTES:${NORMAL}\n"
 	printf "  - If no version is specified, the latest version from FORGEBOX will be installed\n"
 	printf "  - Multiple modules can be specified, separated by spaces or commas\n"
@@ -113,6 +115,7 @@ show_help() {
 	printf "  - Without --local, modules are managed in BoxLang HOME (~/.boxlang/modules)\n"
 	printf "  - Requires curl and jq to be installed\n"
 	printf "  - Dependencies declared in a module's box.json are installed automatically (latest version for \"*\", otherwise the version specified, including \"be\" or \"snapshot\")\n"
+	printf "  - Running with no arguments installs the dependencies declared in a box.json in the current directory, if one exists\n"
 }
 
 list_modules() {
@@ -875,8 +878,22 @@ main() {
 		exit 1
 	fi
 
-	# Check if no arguments are passed
+	# Check if no arguments are passed. If a box.json exists in the current
+	# directory, treat it as a project manifest and install the dependencies
+	# it declares (similar to running `npm install` with no arguments).
 	if [ $# -eq 0 ]; then
+		if [ -f "$(pwd)/box.json" ]; then
+			if [ -z "${BOXLANG_HOME}" ]; then
+				export BOXLANG_HOME="$HOME/.boxlang"
+			fi
+			MODULES_HOME="${BOXLANG_HOME}/modules"
+			LOCAL_INSTALL=false
+
+			printf "${YELLOW}📄 Found box.json in $(pwd), installing its declared dependencies...${NORMAL}\n"
+			install_module_dependencies "$(pwd)" ""
+			exit 0
+		fi
+
 		printf "${RED}❌ Error: No module(s) specified${NORMAL}\n"
 		printf "${YELLOW}💡 This script installs or removes BoxLang modules.${NORMAL}\n"
 		show_help

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -112,7 +112,7 @@ show_help() {
 	printf "  - Use --local to work with modules in current directory's boxlang_modules folder\n"
 	printf "  - Without --local, modules are managed in BoxLang HOME (~/.boxlang/modules)\n"
 	printf "  - Requires curl and jq to be installed\n"
-	printf "  - Dependencies declared in a module's box.json are installed automatically (latest version for \"*\", otherwise the version specified)\n"
+	printf "  - Dependencies declared in a module's box.json are installed automatically (latest version for \"*\", otherwise the version specified, including \"be\" or \"snapshot\")\n"
 }
 
 list_modules() {

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -878,28 +878,6 @@ main() {
 		exit 1
 	fi
 
-	# Check if no arguments are passed. If a box.json exists in the current
-	# directory, treat it as a project manifest and install the dependencies
-	# it declares (similar to running `npm install` with no arguments).
-	if [ $# -eq 0 ]; then
-		if [ -f "$(pwd)/box.json" ]; then
-			if [ -z "${BOXLANG_HOME}" ]; then
-				export BOXLANG_HOME="$HOME/.boxlang"
-			fi
-			MODULES_HOME="${BOXLANG_HOME}/modules"
-			LOCAL_INSTALL=false
-
-			printf "${YELLOW}📄 Found box.json in $(pwd), installing its declared dependencies...${NORMAL}\n"
-			install_module_dependencies "$(pwd)" ""
-			exit 0
-		fi
-
-		printf "${RED}❌ Error: No module(s) specified${NORMAL}\n"
-		printf "${YELLOW}💡 This script installs or removes BoxLang modules.${NORMAL}\n"
-		show_help
-		exit 1
-	fi
-
 	# Show help if requested
 	if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 		show_help
@@ -1098,13 +1076,32 @@ main() {
 		exit 0
 	fi
 
+	# No module names were given (either no arguments at all, or only
+	# --local). If a box.json exists in the current directory, treat it as a
+	# project manifest and install the dependencies it declares (similar to
+	# running `npm install` with no arguments), honoring --local/BoxLang HOME
+	# just like a normal install would.
+	MODULE_LIST=$(parse_module_list "$@")
+	if [ -z "$MODULE_LIST" ]; then
+		if [ -f "$(pwd)/box.json" ]; then
+			printf "${YELLOW}📄 Found box.json in $(pwd), installing its declared dependencies...${NORMAL}\n"
+			install_module_dependencies "$(pwd)" ""
+			exit 0
+		fi
+
+		printf "${RED}❌ Error: No module(s) specified${NORMAL}\n"
+		printf "${YELLOW}💡 This script installs or removes BoxLang modules.${NORMAL}\n"
+		show_help
+		exit 1
+	fi
+
 	# Inform about local installation
 	if [ "$LOCAL_INSTALL" = true ]; then
 		printf "${YELLOW}📍 Installing modules locally in $(pwd)/boxlang_modules${NORMAL}\n"
 	fi
 
-	# Parse comma/space-delimited module list and install
-	parse_module_list "$@" | while IFS= read -r module; do
+	# Install the parsed comma/space-delimited module list
+	printf '%s\n' "$MODULE_LIST" | while IFS= read -r module; do
 		if [ -n "$module" ]; then
 			printf "${GREEN}🚀 Starting installation of module: ${module}${NORMAL}\n"
 			install_module "$module"

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -402,6 +402,44 @@ test_main_no_args_without_box_json_shows_usage_error() {
     assert_contains "No module(s) specified" "$output" "main() falls back to the usage error when no box.json exists"
 }
 
+test_main_local_flag_only_installs_project_box_json_dependencies_locally() {
+    run_test_group "main() with only --local and a project box.json"
+
+    local PROJECT_DIR="$TEST_TMP/project-local-box-json"
+    mkdir -p "$PROJECT_DIR"
+    echo '{"dependencies": {"bx-orm": "*"}}' > "$PROJECT_DIR/box.json"
+
+    # Fake jq reporting one dependency, used by the real install_module_dependencies
+    local BIN_JQ="$TEST_TMP/bin-jqlocal"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "1" ;;
+	*to_entries*) printf 'bx-orm\t*\n' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local CALLS_FILE="$TEST_TMP/main_local_calls.txt"
+    : > "$CALLS_FILE"
+
+    local output rc
+    output=$(
+        install_module() {
+            printf 'module=%s MODULES_HOME=%s LOCAL_INSTALL=%s\n' "$1" "$MODULES_HOME" "$LOCAL_INSTALL" >> "$CALLS_FILE"
+        }
+        cd "$PROJECT_DIR" && PATH="$BIN_JQ:$PATH" main --local 2>&1
+    )
+    rc=$?
+
+    assert_return_code 0 "$rc" "main() with --local only and a box.json exits 0"
+    assert_contains "Found box.json" "$output" "main() reports finding the project box.json under --local"
+    assert_contains "MODULES_HOME=$PROJECT_DIR/boxlang_modules" "$(cat "$CALLS_FILE")" "main() installs project dependencies into the local boxlang_modules directory"
+    assert_contains "LOCAL_INSTALL=true" "$(cat "$CALLS_FILE")" "main() keeps LOCAL_INSTALL true when installing project dependencies via --local"
+}
+
 run_all_tests() {
     test_list_modules_jq_failure
     test_list_modules_empty_manifest
@@ -412,6 +450,7 @@ run_all_tests() {
     test_install_module_dependencies_skips_circular_dependency
     test_main_no_args_installs_project_box_json_dependencies
     test_main_no_args_without_box_json_shows_usage_error
+    test_main_local_flag_only_installs_project_box_json_dependencies_locally
 
     # Print summary
     echo ""

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -260,6 +260,7 @@ EOF
 
     # Restore the real install_module for subsequent tests
     . "$SITE_DIR/install-bx-module.sh"
+    set +e
 }
 
 test_install_module_dependencies_installs_be_and_snapshot_versions() {
@@ -297,6 +298,7 @@ EOF
     assert_contains "bx-ai@snapshot" "$calls" "install_module_dependencies() passes through a 'snapshot' dependency version"
 
     . "$SITE_DIR/install-bx-module.sh"
+    set +e
 }
 
 test_install_module_dependencies_no_box_json() {
@@ -318,6 +320,7 @@ test_install_module_dependencies_no_box_json() {
     assert_equals "" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() installs nothing when box.json is missing"
 
     . "$SITE_DIR/install-bx-module.sh"
+    set +e
 }
 
 test_install_module_dependencies_skips_circular_dependency() {
@@ -354,6 +357,49 @@ EOF
     assert_equals "" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() does not install an already-visited dependency"
 
     . "$SITE_DIR/install-bx-module.sh"
+    set +e
+}
+
+###########################################################################
+# Tests for `main` with no arguments (project box.json auto-install)
+###########################################################################
+
+test_main_no_args_installs_project_box_json_dependencies() {
+    run_test_group "main() with no arguments and a project box.json"
+
+    local PROJECT_DIR="$TEST_TMP/project-with-box-json"
+    mkdir -p "$PROJECT_DIR"
+    echo '{"name": "my-app", "dependencies": {"bx-orm": "*"}}' > "$PROJECT_DIR/box.json"
+
+    local CALLS_FILE="$TEST_TMP/main_no_args_calls.txt"
+    : > "$CALLS_FILE"
+
+    local output rc
+    output=$(
+        install_module_dependencies() {
+            printf '%s\t%s\n' "$1" "$2" >> "$CALLS_FILE"
+        }
+        cd "$PROJECT_DIR" && main 2>&1
+    )
+    rc=$?
+
+    assert_return_code 0 "$rc" "main() with no args and a box.json exits 0"
+    assert_contains "Found box.json" "$output" "main() reports finding the project box.json"
+    assert_contains "$PROJECT_DIR" "$(cat "$CALLS_FILE")" "main() installs dependencies from the project's box.json directory"
+}
+
+test_main_no_args_without_box_json_shows_usage_error() {
+    run_test_group "main() with no arguments and no box.json"
+
+    local EMPTY_DIR="$TEST_TMP/project-without-box-json"
+    mkdir -p "$EMPTY_DIR"
+
+    local output rc
+    output=$(cd "$EMPTY_DIR" && main 2>&1)
+    rc=$?
+
+    assert_return_code 1 "$rc" "main() with no args and no box.json exits 1"
+    assert_contains "No module(s) specified" "$output" "main() falls back to the usage error when no box.json exists"
 }
 
 run_all_tests() {
@@ -364,6 +410,8 @@ run_all_tests() {
     test_install_module_dependencies_installs_be_and_snapshot_versions
     test_install_module_dependencies_no_box_json
     test_install_module_dependencies_skips_circular_dependency
+    test_main_no_args_installs_project_box_json_dependencies
+    test_main_no_args_without_box_json_shows_usage_error
 
     # Print summary
     echo ""

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -262,6 +262,43 @@ EOF
     . "$SITE_DIR/install-bx-module.sh"
 }
 
+test_install_module_dependencies_installs_be_and_snapshot_versions() {
+    run_test_group "install_module_dependencies with 'be' and 'snapshot' deps"
+
+    local MODULE_DIR="$TEST_TMP/module-with-be-snapshot-deps"
+    mkdir -p "$MODULE_DIR"
+    echo '{"dependencies": {"bx-orm": "be", "bx-ai": "snapshot"}}' > "$MODULE_DIR/box.json"
+
+    # Fake jq reporting a bleeding-edge dependency and a snapshot dependency
+    local BIN_JQ="$TEST_TMP/bin-jqbesnap"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "2" ;;
+	*to_entries*) printf 'bx-orm\tbe\nbx-ai\tsnapshot\n' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_be_snapshot.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE"
+    }
+
+    PATH="$BIN_JQ:$PATH" install_module_dependencies "$MODULE_DIR" ""
+
+    local calls
+    calls=$(cat "$INSTALL_CALLS_FILE")
+
+    assert_contains "bx-orm@be" "$calls" "install_module_dependencies() passes through a 'be' dependency version"
+    assert_contains "bx-ai@snapshot" "$calls" "install_module_dependencies() passes through a 'snapshot' dependency version"
+
+    . "$SITE_DIR/install-bx-module.sh"
+}
+
 test_install_module_dependencies_no_box_json() {
     run_test_group "install_module_dependencies with no box.json"
 
@@ -324,6 +361,7 @@ run_all_tests() {
     test_list_modules_empty_manifest
     test_list_modules_with_installed_modules
     test_install_module_dependencies_installs_wildcard_and_pinned_versions
+    test_install_module_dependencies_installs_be_and_snapshot_versions
     test_install_module_dependencies_no_box_json
     test_install_module_dependencies_skips_circular_dependency
 

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -217,10 +217,115 @@ EOF
     assert_not_contains "Illegal number" "$output" "list_modules() never emits 'Illegal number'"
 }
 
+###########################################################################
+# Tests for install_module_dependencies (box.json dependency installation)
+###########################################################################
+
+test_install_module_dependencies_installs_wildcard_and_pinned_versions() {
+    run_test_group "install_module_dependencies with wildcard and pinned deps"
+
+    local MODULE_DIR="$TEST_TMP/module-with-deps"
+    mkdir -p "$MODULE_DIR"
+    echo '{"dependencies": {"bx-orm": "*", "bx-ai": "2.1.0"}}' > "$MODULE_DIR/box.json"
+
+    # Fake jq reporting two dependencies: one wildcard, one pinned
+    local BIN_JQ="$TEST_TMP/bin-jqdeps"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "2" ;;
+	*to_entries*) printf 'bx-orm\t*\nbx-ai\t2.1.0\n' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    # Stub install_module so we assert on what would be installed instead of
+    # performing a real network install.
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_wildcard.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE"
+    }
+
+    PATH="$BIN_JQ:$PATH" install_module_dependencies "$MODULE_DIR" ""
+
+    local calls
+    calls=$(cat "$INSTALL_CALLS_FILE")
+
+    assert_contains "bx-orm" "$calls" "install_module_dependencies() installs a '*' dependency by name only (latest)"
+    assert_not_contains "bx-orm@" "$calls" "install_module_dependencies() does not pin a '*' dependency to a version"
+    assert_contains "bx-ai@2.1.0" "$calls" "install_module_dependencies() installs a pinned dependency with its exact version"
+
+    # Restore the real install_module for subsequent tests
+    . "$SITE_DIR/install-bx-module.sh"
+}
+
+test_install_module_dependencies_no_box_json() {
+    run_test_group "install_module_dependencies with no box.json"
+
+    local MODULE_DIR="$TEST_TMP/module-without-box-json"
+    mkdir -p "$MODULE_DIR"
+
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_none.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE"
+    }
+
+    install_module_dependencies "$MODULE_DIR" ""
+    local rc=$?
+
+    assert_return_code 0 "$rc" "install_module_dependencies() returns 0 when box.json is missing"
+    assert_equals "" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() installs nothing when box.json is missing"
+
+    . "$SITE_DIR/install-bx-module.sh"
+}
+
+test_install_module_dependencies_skips_circular_dependency() {
+    run_test_group "install_module_dependencies with a circular dependency"
+
+    local MODULE_DIR="$TEST_TMP/module-circular"
+    mkdir -p "$MODULE_DIR"
+    echo '{"dependencies": {"bx-orm": "*"}}' > "$MODULE_DIR/box.json"
+
+    local BIN_JQ="$TEST_TMP/bin-jqcircular"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "1" ;;
+	*to_entries*) printf 'bx-orm\t*\n' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_circular.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE"
+    }
+
+    # "bx-orm" is already in the VISITED chain, so it must be skipped rather
+    # than recursively re-installed.
+    local output
+    output=$(PATH="$BIN_JQ:$PATH" install_module_dependencies "$MODULE_DIR" "bx-root bx-orm" 2>&1)
+
+    assert_contains "Skipping circular dependency" "$output" "install_module_dependencies() reports a skipped circular dependency"
+    assert_equals "" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() does not install an already-visited dependency"
+
+    . "$SITE_DIR/install-bx-module.sh"
+}
+
 run_all_tests() {
     test_list_modules_jq_failure
     test_list_modules_empty_manifest
     test_list_modules_with_installed_modules
+    test_install_module_dependencies_installs_wildcard_and_pinned_versions
+    test_install_module_dependencies_no_box_json
+    test_install_module_dependencies_skips_circular_dependency
 
     # Print summary
     echo ""


### PR DESCRIPTION
When install-bx-module installs a module, check the extracted module's
box.json for a dependencies entry and install each one automatically:
"*" (or an empty/null version) resolves to the latest FORGEBOX version,
any other value installs that exact version. Recursion is guarded
against circular dependency chains. Implemented for both the sh and
PowerShell installers.

Also fixes IFS=$'\t' in install-bx-module.sh, which is a bash/ksh-ism
that POSIX /bin/sh (dash, BusyBox ash) does not expand, so tab-delimited
jq output was never actually being split into fields. Replaced with a
portable IFS="$TAB" built via printf.