### PR TITLE
Fix install-bx-module.ps1 silently doing nothing on bare --remove/--list

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the Windows installer to honor `BOXLANG_INSTALL_HOME` for custom installation paths, while retaining `C:\boxlang` as the default.
 - Fixed `install-bx-module.sh` parsing tab-delimited `jq` output with `IFS=$'\t'`, which POSIX `/bin/sh` (dash, BusyBox ash) does not expand, so fields were never actually being split.
+- Fixed `install-bx-module.ps1 --remove` and `--list` silently doing nothing instead of showing their usage error when called with no other arguments (e.g. `install-bx-module.ps1 --remove` alone). A descending PowerShell range (`1..0`) left the flag itself in the parsed argument list instead of producing an empty one.
 
 ## [1.32.0] - 2026-07-31
 

--- a/src/install-bx-module.ps1
+++ b/src/install-bx-module.ps1
@@ -908,7 +908,10 @@ if ($args[0] -eq "--help" -or $args[0] -eq "-h") {
 # Handle --list command (can be used with --local)
 if ($args[0] -eq "--list") {
     $LIST_MODE = $true
-    $remainingArgs = $args[1..($args.Count-1)]
+    $remainingArgs = @()
+    if ($args.Count -gt 1) {
+        $remainingArgs = $args[1..($args.Count-1)]
+    }
 
     # Check if --local is specified with --list
     $LOCAL_LIST = $false
@@ -1022,7 +1025,10 @@ $currentArgs = $args
 # Check if --remove is the first argument
 if ($args[0] -eq "--remove") {
     $REMOVE_MODE = $true
-    $currentArgs = $args[1..($args.Count-1)]
+    $currentArgs = @()
+    if ($args.Count -gt 1) {
+        $currentArgs = $args[1..($args.Count-1)]
+    }
 
     # Check for --force flag
     if ($currentArgs -contains "--force") {

--- a/tests/powershell/InstallBxModule.Tests.ps1
+++ b/tests/powershell/InstallBxModule.Tests.ps1
@@ -1,0 +1,59 @@
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $PSScriptRoot 'TestFramework.ps1')
+
+Initialize-TestSuite 'PowerShell module installer argument parsing'
+$moduleInstaller = Join-Path $repoRoot 'src\install-bx-module.ps1'
+
+function Invoke-ModuleInstaller {
+    param([string[]]$InstallerArguments)
+
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ('bx-module-installer-' + [guid]::NewGuid())
+    $fakeHome = Join-Path $root 'home'
+    [System.IO.Directory]::CreateDirectory($fakeHome) | Out-Null
+
+    $previousLocation = Get-Location
+    $previousBoxlangHome = $env:BOXLANG_HOME
+    try {
+        Set-Location $root
+        $env:BOXLANG_HOME = $fakeHome
+        $output = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $moduleInstaller @InstallerArguments 2>&1 | Out-String
+        return @{ Output = $output; ExitCode = $LASTEXITCODE }
+    }
+    finally {
+        Set-Location $previousLocation
+        if ($null -eq $previousBoxlangHome) { Remove-Item Env:BOXLANG_HOME -ErrorAction SilentlyContinue } else { $env:BOXLANG_HOME = $previousBoxlangHome }
+        Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Invoke-Test '--remove with no module name shows a usage error instead of doing nothing' {
+    $result = Invoke-ModuleInstaller -InstallerArguments @('--remove')
+    Assert-Equal 1 $result.ExitCode '--remove with no module name should exit 1'
+    Assert-Match 'No module\(s\) specified for removal' $result.Output '--remove with no module name did not show the usage error'
+}
+
+Invoke-Test '--remove --local with no module name shows a usage error instead of doing nothing' {
+    $result = Invoke-ModuleInstaller -InstallerArguments @('--remove', '--local')
+    Assert-Equal 1 $result.ExitCode '--remove --local with no module name should exit 1'
+    Assert-Match 'No module\(s\) specified for removal' $result.Output '--remove --local with no module name did not show the usage error'
+}
+
+Invoke-Test '--remove with a module name still works' {
+    $result = Invoke-ModuleInstaller -InstallerArguments @('--remove', 'bx-orm', '--force')
+    Assert-Equal 0 $result.ExitCode '--remove with a module name should succeed'
+    Assert-Match 'Starting removal of module: bx-orm' $result.Output '--remove with a module name did not attempt removal'
+}
+
+Invoke-Test '--list alone still succeeds' {
+    $result = Invoke-ModuleInstaller -InstallerArguments @('--list')
+    Assert-Equal 0 $result.ExitCode '--list alone should succeed'
+    Assert-Match 'Installed BoxLang Modules' $result.Output '--list alone did not show the module listing header'
+}
+
+Invoke-Test '--list --local still succeeds' {
+    $result = Invoke-ModuleInstaller -InstallerArguments @('--list', '--local')
+    Assert-Equal 0 $result.ExitCode '--list --local should succeed'
+    Assert-Match 'Local' $result.Output '--list --local did not report the local location'
+}
+
+Complete-TestSuite

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -376,6 +376,10 @@ test_main_no_args_installs_project_box_json_dependencies() {
 
     local output rc
     output=$(
+        # main() starts with a real preflight_check, which may try to
+        # apt-install curl/unzip/jq on a container lacking them - stub it out
+        # since these tests only exercise the box.json dispatch logic.
+        preflight_check() { return 0; }
         install_module_dependencies() {
             printf '%s\t%s\n' "$1" "$2" >> "$CALLS_FILE"
         }
@@ -395,7 +399,10 @@ test_main_no_args_without_box_json_shows_usage_error() {
     mkdir -p "$EMPTY_DIR"
 
     local output rc
-    output=$(cd "$EMPTY_DIR" && main 2>&1)
+    output=$(
+        preflight_check() { return 0; }
+        cd "$EMPTY_DIR" && main 2>&1
+    )
     rc=$?
 
     assert_return_code 1 "$rc" "main() with no args and no box.json exits 1"
@@ -427,6 +434,7 @@ EOF
 
     local output rc
     output=$(
+        preflight_check() { return 0; }
         install_module() {
             printf 'module=%s MODULES_HOME=%s LOCAL_INSTALL=%s\n' "$1" "$MODULES_HOME" "$LOCAL_INSTALL" >> "$CALLS_FILE"
         }


### PR DESCRIPTION
## Summary
- `install-bx-module.ps1 --remove` (or `--list`) with no other arguments silently did nothing instead of showing "No module(s) specified for removal" / behaving correctly. Root cause: `$args[1..($args.Count-1)]` is meant to drop the flag itself, but when `$args.Count` is exactly 1 that range (`1..0`) descends, and PowerShell drops the out-of-bounds index `1` while keeping index `0` — so the flag string stayed in the parsed argument list instead of being removed. For `--remove`, the leftover `"--remove"` string then got filtered out by `Parse-ModuleList` (it starts with `--`), leaving an empty module list and no error.
- Fixed both blocks with the same `if ($args.Count -gt 1) { ... } else { @() }` guard that `--outdated` and `--update` already used correctly.
- This bug predates and is unrelated to the box.json dependency-install work merged in #53 — found while manually verifying that feature's `--local` handling against a real PowerShell interpreter (installed `pwsh` 7.4.6 locally to test with, since there's no Windows runner in this environment).

## Test plan
- [x] `[System.Management.Automation.Language.Parser]::ParseFile` confirms no syntax errors
- [x] Verified with real PowerShell (pwsh 7.4.6): `--remove` alone and `--list` alone now behave correctly (exit 1 with usage error / exit 0 respectively, matching `--outdated`/`--update` alone)
- [x] Verified `--remove --local` (no module name), `--remove <module> --force`, `--list --local` all unaffected
- [x] Verified the box.json/`--local` project-dependency-install feature from #53 still works after this change
- [x] Added `tests/powershell/InstallBxModule.Tests.ps1` following this repo's existing PowerShell test conventions (subprocess invocation, mocked `BOXLANG_HOME`); validated locally by substituting `pwsh` for `powershell.exe` since Windows isn't available here — all 5 new tests pass
- [x] Ran the existing `tests/powershell/WindowsPrerequisites.Tests.ps1` (imports functions directly from `install-bx-module.ps1`) — still passes
- [x] Updated `changelog.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRUwtaLGe3g24SRZHiTZFH)_