### PR TITLE
Add module bash completions support to install-bx-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,32 @@ If an installed module's own `box.json` declares a `dependencies` entry, those d
 
 Running `install-bx-module` with no module names checks the current directory for its own `box.json`. If one is found, its declared `dependencies` are installed the same way, so a project's dependencies can be installed with a single command, similar to running `npm install` with no arguments. This works both with no arguments at all (installs to BoxLang HOME) and with `--local` alone (installs into `./boxlang_modules`). If no `box.json` is present, the usual usage help is shown instead.
 
+#### Shipping Bash Completions With a Module
+
+A module can ship its own bash completion script and have it installed and auto-loaded automatically. In the module's `box.json`, point `boxlang.completions` at the completion script's path relative to the module root:
+
+```json
+{
+    "name": "bx-orm",
+    "boxlang": {
+        "completions": "completions/bx-orm.bash"
+    }
+}
+```
+
+The script itself (`completions/bx-orm.bash` in the example above) ships inside the module's zip like any other file, and is a normal bash completion script that registers itself, e.g.:
+
+```bash
+#!/usr/bin/env bash
+_bx_orm_complete() {
+    local current_word="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=($(compgen -W "migrate seed generate" -- "$current_word"))
+}
+complete -F _bx_orm_complete bx-orm
+```
+
+On install, `install-bx-module` copies that file to `~/.boxlang/completions/<module-name>.sh` (or `./boxlang_modules/.completions/<module-name>.sh` with `--local`); removing the module deletes it again. Files in that directory are sourced automatically by `bvm-init.sh` in any new Bash or Zsh session, so no extra setup is needed beyond having BVM's shell initialization installed (see [Shell Initialization](BVM-README.md#-shell-initialization) in the BVM guide). To pick up completions for a module installed in the current terminal session without opening a new one, run `source ~/.bvm/scripts/bvm-init.sh` (or `source ~/.bashrc` / `source ~/.zshrc`).
+
 ## 🌐 Running Applications
 
 ### BoxLang Runtime

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `install-bx-module` now installs bash completions declared by a module. A module's `box.json` can point `boxlang.completions` at a bash completion script shipped inside the module; on install it's copied to `~/.boxlang/completions/<module-name>.sh` (or `./boxlang_modules/.completions/<module-name>.sh` with `--local`) and removed again when the module is removed. `bvm-init.sh` auto-sources every script in that directory in new Bash/Zsh sessions.
+
 ### Fixed
 
 - Updated GitHub Actions dispatch for homebrew

--- a/src/bvm-init.sh
+++ b/src/bvm-init.sh
@@ -34,3 +34,13 @@ export PATH
 if [ -s "$BVM_HOME/scripts/bvm-completions.sh" ]; then
     . "$BVM_HOME/scripts/bvm-completions.sh"
 fi
+
+# Load bash completions contributed by installed BoxLang modules (see
+# `boxlang.completions` in a module's box.json). Each module's script is
+# expected to self-register its own `complete` binding.
+if [ -n "${BASH_VERSION:-}${ZSH_VERSION:-}" ] && [ -d "$BOXLANG_HOME/completions" ]; then
+    for bx_completion_file in "$BOXLANG_HOME"/completions/*.sh; do
+        [ -f "$bx_completion_file" ] && . "$bx_completion_file"
+    done
+    unset bx_completion_file
+fi

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -116,6 +116,7 @@ show_help() {
 	printf "  - Requires curl and jq to be installed\n"
 	printf "  - Dependencies declared in a module's box.json are installed automatically (latest version for \"*\", otherwise the version specified, including \"be\" or \"snapshot\")\n"
 	printf "  - Running with no arguments installs the dependencies declared in a box.json in the current directory, if one exists\n"
+	printf "  - A module can declare \"boxlang\": { \"completions\": \"<path-to-bash-completion-script>\" } in its box.json to have a bash completion script installed and auto-loaded in new shells\n"
 }
 
 list_modules() {
@@ -487,6 +488,9 @@ EOF
 				done
 			fi
 		fi
+
+		# Check for boxlang.completions (a bash completion script shipped with the module)
+		install_module_completions "${DESTINATION}" "${TARGET_MODULE}"
 	fi
 
 	# Install any module dependencies declared in the extracted module's box.json
@@ -497,6 +501,57 @@ EOF
 
 	# Success message
 	printf "${GREEN}✅ BoxLang® Module [${TARGET_MODULE}@${TARGET_VERSION}] installed!${NORMAL}\n"
+}
+
+# Resolves the shared completions directory for the current install mode
+# (global BoxLang HOME, or the local boxlang_modules folder with --local).
+completions_dir() {
+	if [ "$LOCAL_INSTALL" = true ]; then
+		echo "$(pwd)/boxlang_modules/.completions"
+	else
+		echo "${BOXLANG_HOME}/completions"
+	fi
+}
+
+# Reads a module's own box.json (as extracted to MODULE_DIR) and, if it
+# declares a `boxlang.completions` path (a bash completion script shipped
+# inside the module, relative to its root), copies that script into the
+# shared completions directory as "<module-name>.sh". bvm-init.sh sources
+# every script in that directory on shell startup, so the completion script
+# is expected to register itself (e.g. via `complete -F ... <command>`).
+install_module_completions() {
+	local MODULE_DIR=${1}
+	local MODULE_NAME=${2}
+	local BOX_JSON_PATH="${MODULE_DIR}/box.json"
+
+	[ -f "${BOX_JSON_PATH}" ] || return 0
+
+	local COMPLETIONS_REL
+	COMPLETIONS_REL=$(jq -r '.boxlang.completions // empty' "${BOX_JSON_PATH}" 2>/dev/null)
+	if [ -z "${COMPLETIONS_REL}" ] || [ "${COMPLETIONS_REL}" = "null" ]; then
+		return 0
+	fi
+
+	local COMPLETIONS_SRC="${MODULE_DIR}/${COMPLETIONS_REL}"
+	if [ ! -f "${COMPLETIONS_SRC}" ]; then
+		printf "${YELLOW}⚠️  Warning: box.json declares completions at '${COMPLETIONS_REL}' but the file was not found in the module${NORMAL}\n"
+		return 0
+	fi
+
+	local COMPLETIONS_DIR
+	COMPLETIONS_DIR=$(completions_dir)
+	mkdir -p "${COMPLETIONS_DIR}"
+	printf "${BLUE}⌨️  Installing bash completions for: ${MODULE_NAME}${NORMAL}\n"
+	cp "${COMPLETIONS_SRC}" "${COMPLETIONS_DIR}/${MODULE_NAME}.sh"
+	chmod 644 "${COMPLETIONS_DIR}/${MODULE_NAME}.sh"
+}
+
+# Removes any bash completion script previously installed for MODULE_NAME.
+remove_module_completions() {
+	local MODULE_NAME=${1}
+	local COMPLETIONS_DIR
+	COMPLETIONS_DIR=$(completions_dir)
+	rm -f "${COMPLETIONS_DIR}/${MODULE_NAME}.sh"
 }
 
 # Reads a module's own box.json (as extracted to MODULE_DIR) and installs any
@@ -603,6 +658,8 @@ remove_module() {
 		printf "${GREEN}✅ Module '${MODULE_NAME}' removed successfully!${NORMAL}\n"
 		# Untrack this module from the modules manifest
 		box_json_remove_dependency "${MODULES_HOME}/box.json" "${MODULE_NAME}"
+		# Remove any bash completions installed for this module
+		remove_module_completions "${MODULE_NAME}"
 	else
 		printf "${RED}❌ Error: Failed to remove module '${MODULE_NAME}'${NORMAL}\n"
 		exit 1

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -361,6 +361,123 @@ EOF
 }
 
 ###########################################################################
+# Tests for install_module_completions / remove_module_completions
+###########################################################################
+
+test_install_module_completions_copies_declared_script() {
+    run_test_group "install_module_completions with a declared completions script"
+
+    local MODULE_DIR="$TEST_TMP/module-with-completions"
+    mkdir -p "$MODULE_DIR/completions"
+    echo '{"boxlang": {"completions": "completions/bx-demo.bash"}}' > "$MODULE_DIR/box.json"
+    printf '#!/usr/bin/env bash\ncomplete -F _bx_demo_complete bx-demo\n' > "$MODULE_DIR/completions/bx-demo.bash"
+
+    local BIN_JQ="$TEST_TMP/bin-jqcompl"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*completions*) echo "completions/bx-demo.bash" ;;
+	*) echo "" ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions"
+    mkdir -p "$BOXLANG_HOME"
+
+    (
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        PATH="$BIN_JQ:$PATH"
+        install_module_completions "$MODULE_DIR" "bx-demo"
+    )
+
+    local installed_file="$BOXLANG_HOME/completions/bx-demo.sh"
+    assert_equals "1" "$([ -f "$installed_file" ] && echo 1 || echo 0)" "install_module_completions() copies the declared script into BOXLANG_HOME/completions"
+    assert_contains "_bx_demo_complete" "$(cat "$installed_file" 2>/dev/null)" "install_module_completions() preserves the completion script's content"
+}
+
+test_install_module_completions_warns_when_declared_file_missing() {
+    run_test_group "install_module_completions with a missing declared script"
+
+    local MODULE_DIR="$TEST_TMP/module-with-missing-completions"
+    mkdir -p "$MODULE_DIR"
+    echo '{"boxlang": {"completions": "completions/does-not-exist.bash"}}' > "$MODULE_DIR/box.json"
+
+    local BIN_JQ="$TEST_TMP/bin-jqcomplmissing"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*completions*) echo "completions/does-not-exist.bash" ;;
+	*) echo "" ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions-missing"
+    mkdir -p "$BOXLANG_HOME"
+
+    local output rc
+    output=$(
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        PATH="$BIN_JQ:$PATH"
+        install_module_completions "$MODULE_DIR" "bx-demo" 2>&1
+    )
+    rc=$?
+
+    assert_return_code 0 "$rc" "install_module_completions() does not fail when the declared file is missing"
+    assert_contains "was not found in the module" "$output" "install_module_completions() warns when the declared completions file is missing"
+    assert_equals "0" "$([ -f "$BOXLANG_HOME/completions/bx-demo.sh" ] && echo 1 || echo 0)" "install_module_completions() installs nothing when the declared file is missing"
+}
+
+test_install_module_completions_noop_without_declaration() {
+    run_test_group "install_module_completions without a boxlang.completions declaration"
+
+    local MODULE_DIR="$TEST_TMP/module-without-completions"
+    mkdir -p "$MODULE_DIR"
+    echo '{"name": "bx-demo"}' > "$MODULE_DIR/box.json"
+
+    local BIN_JQ="$TEST_TMP/bin-jqcomplnone"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+echo ""
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions-none"
+    mkdir -p "$BOXLANG_HOME"
+
+    (
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        PATH="$BIN_JQ:$PATH"
+        install_module_completions "$MODULE_DIR" "bx-demo"
+    )
+
+    assert_equals "0" "$([ -d "$BOXLANG_HOME/completions" ] && echo 1 || echo 0)" "install_module_completions() creates no completions directory without a declaration"
+}
+
+test_remove_module_completions_deletes_installed_script() {
+    run_test_group "remove_module_completions"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions-remove"
+    mkdir -p "$BOXLANG_HOME/completions"
+    echo 'complete -F _bx_demo_complete bx-demo' > "$BOXLANG_HOME/completions/bx-demo.sh"
+
+    (
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        remove_module_completions "bx-demo"
+    )
+
+    assert_equals "0" "$([ -f "$BOXLANG_HOME/completions/bx-demo.sh" ] && echo 1 || echo 0)" "remove_module_completions() deletes the installed completion script"
+}
+
+###########################################################################
 # Tests for `main` with no arguments (project box.json auto-install)
 ###########################################################################
 
@@ -456,6 +573,10 @@ run_all_tests() {
     test_install_module_dependencies_installs_be_and_snapshot_versions
     test_install_module_dependencies_no_box_json
     test_install_module_dependencies_skips_circular_dependency
+    test_install_module_completions_copies_declared_script
+    test_install_module_completions_warns_when_declared_file_missing
+    test_install_module_completions_noop_without_declaration
+    test_remove_module_completions_deletes_installed_script
     test_main_no_args_installs_project_box_json_dependencies
     test_main_no_args_without_box_json_shows_usage_error
     test_main_local_flag_only_installs_project_box_json_dependencies_locally


### PR DESCRIPTION
## Summary

- `install-bx-module` now installs bash completions declared by a module. A module's `box.json` can point `boxlang.completions` at a bash completion script shipped inside the module.
- On install, the script is copied to `~/.boxlang/completions/<module-name>.sh` (or `./boxlang_modules/.completions/<module-name>.sh` with `--local`), and removed again when the module is removed.
- `bvm-init.sh` now auto-sources every script in the completions directory in new Bash/Zsh sessions, so a module's completions "just work" after install with no extra shell setup.
- Refactored the install/remove logic into standalone `install_module_completions()` / `remove_module_completions()` functions for testability, mirroring the existing `install_module_dependencies()` pattern.
- Added README documentation for the `boxlang.completions` convention, a changelog entry, and unit tests.

## Test plan

- [x] `sh -n` syntax-checked `install-bx-module.sh` and `bvm-init.sh`
- [x] `sh tests/specs/install_bx_module_test.sh` — all 34 tests pass, including 4 new tests covering `install_module_completions()` (declared script copied, missing declared file warns without failing, no-op without a declaration) and `remove_module_completions()`
- [ ] Manual smoke test: install a module declaring `boxlang.completions`, open a new shell, confirm the completion is registered

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTQzbDKpBvGBp252hED7sK)_