### PR TITLE
Version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,4 +191,4 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer ${{ secrets.GHA_WORKFLOW_DISPATCHER_PAT_BOXLANG }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d '{ "event_type":"installer-released" }'
+            -d '{ "ref":"main" }'

--- a/README.md
+++ b/README.md
@@ -351,6 +351,32 @@ If an installed module's own `box.json` declares a `dependencies` entry, those d
 
 Running `install-bx-module` with no module names checks the current directory for its own `box.json`. If one is found, its declared `dependencies` are installed the same way, so a project's dependencies can be installed with a single command, similar to running `npm install` with no arguments. This works both with no arguments at all (installs to BoxLang HOME) and with `--local` alone (installs into `./boxlang_modules`). If no `box.json` is present, the usual usage help is shown instead.
 
+#### Shipping Bash Completions With a Module
+
+A module can ship its own bash completion script and have it installed and auto-loaded automatically. In the module's `box.json`, point `boxlang.completions` at the completion script's path relative to the module root:
+
+```json
+{
+    "name": "bx-orm",
+    "boxlang": {
+        "completions": "completions/bx-orm.bash"
+    }
+}
+```
+
+The script itself (`completions/bx-orm.bash` in the example above) ships inside the module's zip like any other file, and is a normal bash completion script that registers itself, e.g.:
+
+```bash
+#!/usr/bin/env bash
+_bx_orm_complete() {
+    local current_word="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=($(compgen -W "migrate seed generate" -- "$current_word"))
+}
+complete -F _bx_orm_complete bx-orm
+```
+
+On install, `install-bx-module` copies that file to `~/.boxlang/completions/<module-name>.sh` (or `./boxlang_modules/.completions/<module-name>.sh` with `--local`); removing the module deletes it again. Files in that directory are sourced automatically by `bvm-init.sh` in any new Bash or Zsh session, so no extra setup is needed beyond having BVM's shell initialization installed (see [Shell Initialization](BVM-README.md#-shell-initialization) in the BVM guide). To pick up completions for a module installed in the current terminal session without opening a new one, run `source ~/.bvm/scripts/bvm-init.sh` (or `source ~/.bashrc` / `source ~/.zshrc`).
+
 ## 🌐 Running Applications
 
 ### BoxLang Runtime

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated GitHub Actions dispatch for homebrew
+
 ## [1.33.0] - 2026-08-20
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated GitHub Actions dispatch for homebrew
+- `install-bx-module` no longer aborts installing a module when one of its `box.json` `dependencies` entries is a CommandBox-style Maven/URL/git dependency (e.g. `"org.jline:jline": "maven:org.jline:jline:3.21.0"`) rather than a plain ForgeBox module slug. Those entries are now detected and skipped with a warning instead of being attempted -- and always failing -- as a ForgeBox install. A ForgeBox-looking dependency whose install genuinely fails (e.g. a transient download error) now also just warns and continues on to the remaining dependencies instead of failing the whole module installation.
 
 ## [1.33.0] - 2026-08-20
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-08-20
+
 ### Added
 
 - Added `--non-interactive` to the BoxLang installers. It skips prompts using their existing defaults and is enabled automatically when standard input is redirected.
@@ -484,7 +486,8 @@ The installer scripts are now installed to: `/usr/local/bin`. So you can reuse t
 
 - Initial release
 
-[unreleased]: https://github.com/ortus-boxlang/boxlang-quick-installer/compare/v1.32.0...HEAD
+[unreleased]: https://github.com/ortus-boxlang/boxlang-quick-installer/compare/v1.33.0...HEAD
+[1.33.0]: https://github.com/ortus-boxlang/boxlang-quick-installer/compare/v1.32.0...v1.33.0
 [1.32.0]: https://github.com/ortus-boxlang/boxlang-quick-installer/compare/v1.31.0...v1.32.0
 [1.31.0]: https://github.com/ortus-boxlang/boxlang-quick-installer/compare/v1.30.0...v1.31.0
 [1.30.0]: https://github.com/ortus-boxlang/boxlang-quick-installer/compare/v1.29.0...v1.30.0

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `install-bx-module` now installs bash completions declared by a module. A module's `box.json` can point `boxlang.completions` at a bash completion script shipped inside the module; on install it's copied to `~/.boxlang/completions/<module-name>.sh` (or `./boxlang_modules/.completions/<module-name>.sh` with `--local`) and removed again when the module is removed. `bvm-init.sh` auto-sources every script in that directory in new Bash/Zsh sessions.
+
 ### Fixed
 
 - Updated GitHub Actions dispatch for homebrew

--- a/src/bvm-init.sh
+++ b/src/bvm-init.sh
@@ -34,3 +34,13 @@ export PATH
 if [ -s "$BVM_HOME/scripts/bvm-completions.sh" ]; then
     . "$BVM_HOME/scripts/bvm-completions.sh"
 fi
+
+# Load bash completions contributed by installed BoxLang modules (see
+# `boxlang.completions` in a module's box.json). Each module's script is
+# expected to self-register its own `complete` binding.
+if [ -n "${BASH_VERSION:-}${ZSH_VERSION:-}" ] && [ -d "$BOXLANG_HOME/completions" ]; then
+    for bx_completion_file in "$BOXLANG_HOME"/completions/*.sh; do
+        [ -f "$bx_completion_file" ] && . "$bx_completion_file"
+    done
+    unset bx_completion_file
+fi

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -116,6 +116,7 @@ show_help() {
 	printf "  - Requires curl and jq to be installed\n"
 	printf "  - Dependencies declared in a module's box.json are installed automatically (latest version for \"*\", otherwise the version specified, including \"be\" or \"snapshot\")\n"
 	printf "  - Running with no arguments installs the dependencies declared in a box.json in the current directory, if one exists\n"
+	printf "  - A module can declare \"boxlang\": { \"completions\": \"<path-to-bash-completion-script>\" } in its box.json to have a bash completion script installed and auto-loaded in new shells\n"
 }
 
 list_modules() {
@@ -487,6 +488,9 @@ EOF
 				done
 			fi
 		fi
+
+		# Check for boxlang.completions (a bash completion script shipped with the module)
+		install_module_completions "${DESTINATION}" "${TARGET_MODULE}"
 	fi
 
 	# Install any module dependencies declared in the extracted module's box.json
@@ -497,6 +501,57 @@ EOF
 
 	# Success message
 	printf "${GREEN}✅ BoxLang® Module [${TARGET_MODULE}@${TARGET_VERSION}] installed!${NORMAL}\n"
+}
+
+# Resolves the shared completions directory for the current install mode
+# (global BoxLang HOME, or the local boxlang_modules folder with --local).
+completions_dir() {
+	if [ "$LOCAL_INSTALL" = true ]; then
+		echo "$(pwd)/boxlang_modules/.completions"
+	else
+		echo "${BOXLANG_HOME}/completions"
+	fi
+}
+
+# Reads a module's own box.json (as extracted to MODULE_DIR) and, if it
+# declares a `boxlang.completions` path (a bash completion script shipped
+# inside the module, relative to its root), copies that script into the
+# shared completions directory as "<module-name>.sh". bvm-init.sh sources
+# every script in that directory on shell startup, so the completion script
+# is expected to register itself (e.g. via `complete -F ... <command>`).
+install_module_completions() {
+	local MODULE_DIR=${1}
+	local MODULE_NAME=${2}
+	local BOX_JSON_PATH="${MODULE_DIR}/box.json"
+
+	[ -f "${BOX_JSON_PATH}" ] || return 0
+
+	local COMPLETIONS_REL
+	COMPLETIONS_REL=$(jq -r '.boxlang.completions // empty' "${BOX_JSON_PATH}" 2>/dev/null)
+	if [ -z "${COMPLETIONS_REL}" ] || [ "${COMPLETIONS_REL}" = "null" ]; then
+		return 0
+	fi
+
+	local COMPLETIONS_SRC="${MODULE_DIR}/${COMPLETIONS_REL}"
+	if [ ! -f "${COMPLETIONS_SRC}" ]; then
+		printf "${YELLOW}⚠️  Warning: box.json declares completions at '${COMPLETIONS_REL}' but the file was not found in the module${NORMAL}\n"
+		return 0
+	fi
+
+	local COMPLETIONS_DIR
+	COMPLETIONS_DIR=$(completions_dir)
+	mkdir -p "${COMPLETIONS_DIR}"
+	printf "${BLUE}⌨️  Installing bash completions for: ${MODULE_NAME}${NORMAL}\n"
+	cp "${COMPLETIONS_SRC}" "${COMPLETIONS_DIR}/${MODULE_NAME}.sh"
+	chmod 644 "${COMPLETIONS_DIR}/${MODULE_NAME}.sh"
+}
+
+# Removes any bash completion script previously installed for MODULE_NAME.
+remove_module_completions() {
+	local MODULE_NAME=${1}
+	local COMPLETIONS_DIR
+	COMPLETIONS_DIR=$(completions_dir)
+	rm -f "${COMPLETIONS_DIR}/${MODULE_NAME}.sh"
 }
 
 # Reads a module's own box.json (as extracted to MODULE_DIR) and installs any
@@ -603,6 +658,8 @@ remove_module() {
 		printf "${GREEN}✅ Module '${MODULE_NAME}' removed successfully!${NORMAL}\n"
 		# Untrack this module from the modules manifest
 		box_json_remove_dependency "${MODULES_HOME}/box.json" "${MODULE_NAME}"
+		# Remove any bash completions installed for this module
+		remove_module_completions "${MODULE_NAME}"
 	else
 		printf "${RED}❌ Error: Failed to remove module '${MODULE_NAME}'${NORMAL}\n"
 		exit 1

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -590,6 +590,24 @@ install_module_dependencies() {
 				;;
 		esac
 
+		# This installer only knows how to resolve plain ForgeBox module slugs.
+		# A box.json dependencies entry can also be a CommandBox-style Maven,
+		# URL, or git dependency (e.g. "org.jline:jline": "maven:org.jline:jline:3.21.0"),
+		# which this script cannot install. Detect those and skip them instead
+		# of attempting -- and always failing -- a ForgeBox lookup for them.
+		case "$dep_name" in
+			*:*)
+				printf "${YELLOW}⚠️  Skipping non-ForgeBox dependency '${dep_name}': not a plain module slug${NORMAL}\n"
+				continue
+				;;
+		esac
+		case "$dep_version" in
+			maven:*|http://*|https://*|git+*|file:*)
+				printf "${YELLOW}⚠️  Skipping non-ForgeBox dependency '${dep_name}': unsupported source '${dep_version}'${NORMAL}\n"
+				continue
+				;;
+		esac
+
 		local dep_input
 		if [ -z "$dep_version" ] || [ "$dep_version" = "null" ] || [ "$dep_version" = "*" ]; then
 			dep_input="${dep_name}"
@@ -598,7 +616,12 @@ install_module_dependencies() {
 		fi
 
 		printf "${GREEN}📦 Installing dependency: ${dep_input}${NORMAL}\n"
-		install_module "$dep_input" "${VISITED}"
+		# Run in a subshell so a hard `exit 1` inside install_module (e.g. a
+		# failed download) only ends this one dependency attempt, not the
+		# whole module installation.
+		if ! ( install_module "$dep_input" "${VISITED}" ); then
+			printf "${YELLOW}⚠️  Warning: Failed to install dependency '${dep_input}', continuing...${NORMAL}\n"
+		fi
 	done
 }
 

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -360,6 +360,91 @@ EOF
     set +e
 }
 
+test_install_module_dependencies_skips_non_forgebox_maven_dependency() {
+    run_test_group "install_module_dependencies with a Maven-style dependency"
+
+    local MODULE_DIR="$TEST_TMP/module-maven-dep"
+    mkdir -p "$MODULE_DIR"
+    echo '{"dependencies": {"org.jline:jline": "maven:org.jline:jline:3.21.0", "bx-orm": "*"}}' > "$MODULE_DIR/box.json"
+
+    # Fake jq reporting a Maven coordinate dependency alongside a normal one
+    local BIN_JQ="$TEST_TMP/bin-jqmaven"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "2" ;;
+	*to_entries*) printf 'org.jline:jline	maven:org.jline:jline:3.21.0
+bx-orm	*
+' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_maven.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE"
+    }
+
+    # A Maven coordinate is not a ForgeBox module slug and must be skipped
+    # (with a warning) rather than attempted -- and failed -- as one.
+    local output
+    output=$(PATH="$BIN_JQ:$PATH" install_module_dependencies "$MODULE_DIR" "" 2>&1)
+
+    assert_contains "Skipping non-ForgeBox dependency" "$output" "install_module_dependencies() reports a skipped Maven dependency"
+    assert_not_contains "org.jline:jline" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() does not attempt to install a Maven coordinate as a ForgeBox module"
+    assert_contains "bx-orm" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() still installs a normal ForgeBox dependency alongside a skipped one"
+
+    . "$SITE_DIR/install-bx-module.sh"
+    set +e
+}
+
+test_install_module_dependencies_continues_after_a_failed_dependency() {
+    run_test_group "install_module_dependencies with a failing dependency install"
+
+    local MODULE_DIR="$TEST_TMP/module-failing-dep"
+    mkdir -p "$MODULE_DIR"
+    echo '{"dependencies": {"bx-orm": "*", "bx-ai": "2.1.0"}}' > "$MODULE_DIR/box.json"
+
+    local BIN_JQ="$TEST_TMP/bin-jqfailing"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "2" ;;
+	*to_entries*) printf 'bx-orm	*
+bx-ai	2.1.0
+' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    # Simulate a ForgeBox-looking dependency whose install still fails (e.g. a
+    # transient download error): bx-orm exits 1, bx-ai succeeds.
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_failing.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        case "$1" in
+            bx-orm) return 1 ;;
+            *) printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE" ;;
+        esac
+    }
+
+    local output
+    output=$(PATH="$BIN_JQ:$PATH" install_module_dependencies "$MODULE_DIR" "" 2>&1)
+    local rc=$?
+
+    assert_return_code 0 "$rc" "install_module_dependencies() does not abort when a dependency install fails"
+    assert_contains "Warning: Failed to install dependency 'bx-orm'" "$output" "install_module_dependencies() warns about the failed dependency"
+    assert_contains "bx-ai@2.1.0" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() still installs the next dependency after a failure"
+
+    . "$SITE_DIR/install-bx-module.sh"
+    set +e
+}
+
 ###########################################################################
 # Tests for install_module_completions / remove_module_completions
 ###########################################################################
@@ -573,6 +658,8 @@ run_all_tests() {
     test_install_module_dependencies_installs_be_and_snapshot_versions
     test_install_module_dependencies_no_box_json
     test_install_module_dependencies_skips_circular_dependency
+    test_install_module_dependencies_skips_non_forgebox_maven_dependency
+    test_install_module_dependencies_continues_after_a_failed_dependency
     test_install_module_completions_copies_declared_script
     test_install_module_completions_warns_when_declared_file_missing
     test_install_module_completions_noop_without_declaration

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -361,6 +361,123 @@ EOF
 }
 
 ###########################################################################
+# Tests for install_module_completions / remove_module_completions
+###########################################################################
+
+test_install_module_completions_copies_declared_script() {
+    run_test_group "install_module_completions with a declared completions script"
+
+    local MODULE_DIR="$TEST_TMP/module-with-completions"
+    mkdir -p "$MODULE_DIR/completions"
+    echo '{"boxlang": {"completions": "completions/bx-demo.bash"}}' > "$MODULE_DIR/box.json"
+    printf '#!/usr/bin/env bash\ncomplete -F _bx_demo_complete bx-demo\n' > "$MODULE_DIR/completions/bx-demo.bash"
+
+    local BIN_JQ="$TEST_TMP/bin-jqcompl"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*completions*) echo "completions/bx-demo.bash" ;;
+	*) echo "" ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions"
+    mkdir -p "$BOXLANG_HOME"
+
+    (
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        PATH="$BIN_JQ:$PATH"
+        install_module_completions "$MODULE_DIR" "bx-demo"
+    )
+
+    local installed_file="$BOXLANG_HOME/completions/bx-demo.sh"
+    assert_equals "1" "$([ -f "$installed_file" ] && echo 1 || echo 0)" "install_module_completions() copies the declared script into BOXLANG_HOME/completions"
+    assert_contains "_bx_demo_complete" "$(cat "$installed_file" 2>/dev/null)" "install_module_completions() preserves the completion script's content"
+}
+
+test_install_module_completions_warns_when_declared_file_missing() {
+    run_test_group "install_module_completions with a missing declared script"
+
+    local MODULE_DIR="$TEST_TMP/module-with-missing-completions"
+    mkdir -p "$MODULE_DIR"
+    echo '{"boxlang": {"completions": "completions/does-not-exist.bash"}}' > "$MODULE_DIR/box.json"
+
+    local BIN_JQ="$TEST_TMP/bin-jqcomplmissing"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*completions*) echo "completions/does-not-exist.bash" ;;
+	*) echo "" ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions-missing"
+    mkdir -p "$BOXLANG_HOME"
+
+    local output rc
+    output=$(
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        PATH="$BIN_JQ:$PATH"
+        install_module_completions "$MODULE_DIR" "bx-demo" 2>&1
+    )
+    rc=$?
+
+    assert_return_code 0 "$rc" "install_module_completions() does not fail when the declared file is missing"
+    assert_contains "was not found in the module" "$output" "install_module_completions() warns when the declared completions file is missing"
+    assert_equals "0" "$([ -f "$BOXLANG_HOME/completions/bx-demo.sh" ] && echo 1 || echo 0)" "install_module_completions() installs nothing when the declared file is missing"
+}
+
+test_install_module_completions_noop_without_declaration() {
+    run_test_group "install_module_completions without a boxlang.completions declaration"
+
+    local MODULE_DIR="$TEST_TMP/module-without-completions"
+    mkdir -p "$MODULE_DIR"
+    echo '{"name": "bx-demo"}' > "$MODULE_DIR/box.json"
+
+    local BIN_JQ="$TEST_TMP/bin-jqcomplnone"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+echo ""
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions-none"
+    mkdir -p "$BOXLANG_HOME"
+
+    (
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        PATH="$BIN_JQ:$PATH"
+        install_module_completions "$MODULE_DIR" "bx-demo"
+    )
+
+    assert_equals "0" "$([ -d "$BOXLANG_HOME/completions" ] && echo 1 || echo 0)" "install_module_completions() creates no completions directory without a declaration"
+}
+
+test_remove_module_completions_deletes_installed_script() {
+    run_test_group "remove_module_completions"
+
+    local BOXLANG_HOME="$TEST_TMP/boxlang-home-completions-remove"
+    mkdir -p "$BOXLANG_HOME/completions"
+    echo 'complete -F _bx_demo_complete bx-demo' > "$BOXLANG_HOME/completions/bx-demo.sh"
+
+    (
+        LOCAL_INSTALL=false
+        BOXLANG_HOME="$BOXLANG_HOME"
+        remove_module_completions "bx-demo"
+    )
+
+    assert_equals "0" "$([ -f "$BOXLANG_HOME/completions/bx-demo.sh" ] && echo 1 || echo 0)" "remove_module_completions() deletes the installed completion script"
+}
+
+###########################################################################
 # Tests for `main` with no arguments (project box.json auto-install)
 ###########################################################################
 
@@ -456,6 +573,10 @@ run_all_tests() {
     test_install_module_dependencies_installs_be_and_snapshot_versions
     test_install_module_dependencies_no_box_json
     test_install_module_dependencies_skips_circular_dependency
+    test_install_module_completions_copies_declared_script
+    test_install_module_completions_warns_when_declared_file_missing
+    test_install_module_completions_noop_without_declaration
+    test_remove_module_completions_deletes_installed_script
     test_main_no_args_installs_project_box_json_dependencies
     test_main_no_args_without_box_json_shows_usage_error
     test_main_local_flag_only_installs_project_box_json_dependencies_locally

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "INSTALLER_VERSION": "1.33.0"
+  "INSTALLER_VERSION": "1.34.0"
 }


### PR DESCRIPTION
This pull request adds support for BoxLang modules to ship their own Bash completion scripts, which are automatically installed and loaded into the user's shell when a module is installed or removed when it is uninstalled. It also updates documentation, changelogs, and test coverage to reflect and verify this new feature. Additionally, a minor fix was made to the GitHub Actions workflow dispatch for Homebrew.

**Bash Completion Script Support for Modules**
- `src/install-bx-module.sh`, `src/bvm-init.sh`: Added logic to detect a `boxlang.completions` entry in a module's `box.json`, copy the specified completion script to a shared completions directory, and ensure it is auto-sourced in new Bash/Zsh sessions. Removal of a module also cleans up its completion script. [[1]](diffhunk://#diff-e259bfd1f267ef4e6fa3a7e3f25aa1a082d37cad7f1863367d4d469bca842accR491-R493) [[2]](diffhunk://#diff-e259bfd1f267ef4e6fa3a7e3f25aa1a082d37cad7f1863367d4d469bca842accR506-R556) [[3]](diffhunk://#diff-e259bfd1f267ef4e6fa3a7e3f25aa1a082d37cad7f1863367d4d469bca842accR661-R662) [[4]](diffhunk://#diff-9cb2aad1ed7b1656ef0291bd89791bf4d400c4e339b161f2475202a4b9d72716R37-R46)
- `README.md`, `changelog.md`: Updated documentation to describe how modules can declare and ship completion scripts, and how these are handled by the installer. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R354-R379) [[2]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R14-R23)

**Test Coverage**
- [`tests/specs/install_bx_module_test.sh`](diffhunk://#diff-14ff53ba61c663d6f13dc911cf9c0c379538ebf7c21e67d7e019ca75a9b0ba5eR363-R479): Added tests to verify that declared completion scripts are installed, missing scripts produce warnings, and removal works as expected. [[1]](diffhunk://#diff-14ff53ba61c663d6f13dc911cf9c0c379538ebf7c21e67d7e019ca75a9b0ba5eR363-R479) [[2]](diffhunk://#diff-14ff53ba61c663d6f13dc911cf9c0c379538ebf7c21e67d7e019ca75a9b0ba5eR576-R579)

**Other Improvements**
- [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L194-R194): Updated the GitHub Actions workflow dispatch payload for Homebrew.
- `version.json`, `changelog.md`: Bumped installer version to 1.34.0 and updated release links. [[1]](diffhunk://#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL2-R2) [[2]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3L487-R498)