### PR TITLE
Fix install-bx-module aborting install on non-ForgeBox box.json dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated GitHub Actions dispatch for homebrew
+- `install-bx-module` no longer aborts installing a module when one of its `box.json` `dependencies` entries is a CommandBox-style Maven/URL/git dependency (e.g. `"org.jline:jline": "maven:org.jline:jline:3.21.0"`) rather than a plain ForgeBox module slug. Those entries are now detected and skipped with a warning instead of being attempted -- and always failing -- as a ForgeBox install. A ForgeBox-looking dependency whose install genuinely fails (e.g. a transient download error) now also just warns and continues on to the remaining dependencies instead of failing the whole module installation.
 
 ## [1.33.0] - 2026-08-20
 

--- a/src/install-bx-module.sh
+++ b/src/install-bx-module.sh
@@ -590,6 +590,24 @@ install_module_dependencies() {
 				;;
 		esac
 
+		# This installer only knows how to resolve plain ForgeBox module slugs.
+		# A box.json dependencies entry can also be a CommandBox-style Maven,
+		# URL, or git dependency (e.g. "org.jline:jline": "maven:org.jline:jline:3.21.0"),
+		# which this script cannot install. Detect those and skip them instead
+		# of attempting -- and always failing -- a ForgeBox lookup for them.
+		case "$dep_name" in
+			*:*)
+				printf "${YELLOW}⚠️  Skipping non-ForgeBox dependency '${dep_name}': not a plain module slug${NORMAL}\n"
+				continue
+				;;
+		esac
+		case "$dep_version" in
+			maven:*|http://*|https://*|git+*|file:*)
+				printf "${YELLOW}⚠️  Skipping non-ForgeBox dependency '${dep_name}': unsupported source '${dep_version}'${NORMAL}\n"
+				continue
+				;;
+		esac
+
 		local dep_input
 		if [ -z "$dep_version" ] || [ "$dep_version" = "null" ] || [ "$dep_version" = "*" ]; then
 			dep_input="${dep_name}"
@@ -598,7 +616,12 @@ install_module_dependencies() {
 		fi
 
 		printf "${GREEN}📦 Installing dependency: ${dep_input}${NORMAL}\n"
-		install_module "$dep_input" "${VISITED}"
+		# Run in a subshell so a hard `exit 1` inside install_module (e.g. a
+		# failed download) only ends this one dependency attempt, not the
+		# whole module installation.
+		if ! ( install_module "$dep_input" "${VISITED}" ); then
+			printf "${YELLOW}⚠️  Warning: Failed to install dependency '${dep_input}', continuing...${NORMAL}\n"
+		fi
 	done
 }
 

--- a/tests/specs/install_bx_module_test.sh
+++ b/tests/specs/install_bx_module_test.sh
@@ -360,6 +360,91 @@ EOF
     set +e
 }
 
+test_install_module_dependencies_skips_non_forgebox_maven_dependency() {
+    run_test_group "install_module_dependencies with a Maven-style dependency"
+
+    local MODULE_DIR="$TEST_TMP/module-maven-dep"
+    mkdir -p "$MODULE_DIR"
+    echo '{"dependencies": {"org.jline:jline": "maven:org.jline:jline:3.21.0", "bx-orm": "*"}}' > "$MODULE_DIR/box.json"
+
+    # Fake jq reporting a Maven coordinate dependency alongside a normal one
+    local BIN_JQ="$TEST_TMP/bin-jqmaven"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "2" ;;
+	*to_entries*) printf 'org.jline:jline	maven:org.jline:jline:3.21.0
+bx-orm	*
+' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_maven.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE"
+    }
+
+    # A Maven coordinate is not a ForgeBox module slug and must be skipped
+    # (with a warning) rather than attempted -- and failed -- as one.
+    local output
+    output=$(PATH="$BIN_JQ:$PATH" install_module_dependencies "$MODULE_DIR" "" 2>&1)
+
+    assert_contains "Skipping non-ForgeBox dependency" "$output" "install_module_dependencies() reports a skipped Maven dependency"
+    assert_not_contains "org.jline:jline" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() does not attempt to install a Maven coordinate as a ForgeBox module"
+    assert_contains "bx-orm" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() still installs a normal ForgeBox dependency alongside a skipped one"
+
+    . "$SITE_DIR/install-bx-module.sh"
+    set +e
+}
+
+test_install_module_dependencies_continues_after_a_failed_dependency() {
+    run_test_group "install_module_dependencies with a failing dependency install"
+
+    local MODULE_DIR="$TEST_TMP/module-failing-dep"
+    mkdir -p "$MODULE_DIR"
+    echo '{"dependencies": {"bx-orm": "*", "bx-ai": "2.1.0"}}' > "$MODULE_DIR/box.json"
+
+    local BIN_JQ="$TEST_TMP/bin-jqfailing"
+    mkdir -p "$BIN_JQ"
+    cat > "$BIN_JQ/jq" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*length*) echo "2" ;;
+	*to_entries*) printf 'bx-orm	*
+bx-ai	2.1.0
+' ;;
+	*) echo '{}' ;;
+esac
+EOF
+    chmod +x "$BIN_JQ/jq"
+
+    # Simulate a ForgeBox-looking dependency whose install still fails (e.g. a
+    # transient download error): bx-orm exits 1, bx-ai succeeds.
+    local INSTALL_CALLS_FILE="$TEST_TMP/install_calls_failing.txt"
+    : > "$INSTALL_CALLS_FILE"
+    install_module() {
+        case "$1" in
+            bx-orm) return 1 ;;
+            *) printf '%s\n' "$1" >> "$INSTALL_CALLS_FILE" ;;
+        esac
+    }
+
+    local output
+    output=$(PATH="$BIN_JQ:$PATH" install_module_dependencies "$MODULE_DIR" "" 2>&1)
+    local rc=$?
+
+    assert_return_code 0 "$rc" "install_module_dependencies() does not abort when a dependency install fails"
+    assert_contains "Warning: Failed to install dependency 'bx-orm'" "$output" "install_module_dependencies() warns about the failed dependency"
+    assert_contains "bx-ai@2.1.0" "$(cat "$INSTALL_CALLS_FILE")" "install_module_dependencies() still installs the next dependency after a failure"
+
+    . "$SITE_DIR/install-bx-module.sh"
+    set +e
+}
+
 ###########################################################################
 # Tests for install_module_completions / remove_module_completions
 ###########################################################################
@@ -573,6 +658,8 @@ run_all_tests() {
     test_install_module_dependencies_installs_be_and_snapshot_versions
     test_install_module_dependencies_no_box_json
     test_install_module_dependencies_skips_circular_dependency
+    test_install_module_dependencies_skips_non_forgebox_maven_dependency
+    test_install_module_dependencies_continues_after_a_failed_dependency
     test_install_module_completions_copies_declared_script
     test_install_module_completions_warns_when_declared_file_missing
     test_install_module_completions_noop_without_declaration


### PR DESCRIPTION
## Summary

`install_module_dependencies()` (added in v1.33.0) iterates a module's `box.json` `dependencies` and installs each one via ForgeBox, treating every entry as a plain ForgeBox module slug. Some `box.json` dependency entries are actually CommandBox-style Maven/URL/git dependencies -- for example, `bx-cli`'s own `box.json` declares `"org.jline:jline": "maven:org.jline:jline:3.21.0"`. Because this installer only understands ForgeBox slugs, it builds a nonsense ForgeBox URL for these, the download 404s, and since `install_module()` calls `exit 1` on a failed download while the whole script runs under `set -e`, that single bad dependency aborts the **entire** module installation -- even for otherwise-healthy modules like `bx-cli` itself. This currently breaks `bx-cli` installs everywhere (confirmed via CI logs in `coldbox-templates/cbGenesis`, where `install-bx-module bx-cli` fails 100% of the time on this exact dependency).

## Fix

- Before attempting to install a `box.json` dependency, detect whether it's a plain ForgeBox slug (dependency name has no `:`, and the version isn't a `maven:`/URL/`git+`/`file:` source). If not, skip it with a warning instead of attempting a doomed ForgeBox install.
- Run each remaining dependency install in a subshell so that if a genuinely ForgeBox-looking dependency still fails to install (e.g. a transient download error), it only warns and continues on to the next dependency instead of aborting the whole module installation via `exit 1` under `set -e`.

## Test plan

- [x] Added `test_install_module_dependencies_skips_non_forgebox_maven_dependency` -- verifies a Maven-style dependency entry is skipped with a warning and never passed to `install_module`, while a normal ForgeBox dependency alongside it still installs.
- [x] Added `test_install_module_dependencies_continues_after_a_failed_dependency` -- verifies a failing ForgeBox-looking dependency install warns and does not abort installation of the remaining dependencies.
- [x] `sh tests/specs/install_bx_module_test.sh` -- 40/40 assertions pass.
- [x] `sh tests/run.sh` (full suite) -- 7/8 suites pass; the one failure (`java_version_test`) is pre-existing, environment-dependent, and unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0155dVd5khZ8m4o645E31Xx8)_